### PR TITLE
fix(test-cdisc_data.R): fixed a failing test

### DIFF
--- a/man/DatetimeFilterState.Rd
+++ b/man/DatetimeFilterState.Rd
@@ -51,7 +51,7 @@ isolate(filter_state$get_call())
 \if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
 Initialize a \code{FilterState} object. This class
-have a extra fields which is \code{private$timezone} which is set to \code{Sys.timezone()} by
+has an extra field, \code{private$timezone}, which is set to \code{Sys.timezone()} by
 default. However, in case when using this module in \code{teal} app, one needs
 timezone of the app user. App user timezone is taken from \code{session$userData$timezone}
 and is set only if object is initialized in \code{shiny}.

--- a/tests/testthat/test-cdisc_data.R
+++ b/tests/testthat/test-cdisc_data.R
@@ -722,6 +722,11 @@ test_that("Naming list elements", {
 })
 
 test_that("List values", {
+  test_relational_data_equal <- function(data1, data2) {
+    testthat::expect_equal(data1$get_items(), data2$get_items())
+    testthat::expect_equal(data1$get_join_keys(), data2$get_join_keys())
+    testthat::expect_equal(data1$get_ui("test"), data2$get_ui("test"))
+  }
 
   result <- cdisc_data(cdisc_dataset("ADSL", ADSL))
 
@@ -738,7 +743,7 @@ test_that("List values", {
 
   result_to_compare <- do.call("cdisc_data", datasets)
 
-  expect_equal(result, result_to_compare)
+  test_relational_data_equal(result, result_to_compare)
 
 
   result <- cdisc_data(cdisc_dataset("ADSL", ADSL), cdisc_dataset("ADTTE", ADTTE))
@@ -761,7 +766,7 @@ test_that("List values", {
 
   result_to_compare <- do.call("cdisc_data", datasets)
 
-  expect_equal(result, result_to_compare)
+  test_relational_data_equal(result, result_to_compare)
 })
 
 test_that("Keys in cached datasets", {


### PR DESCRIPTION
* test was failing due to a piece of code in RelationalData assigning an id based on a hash of Sys.time()
* also added missing documentation for DatetimeFilterState.Rd

Closes #127