### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -33,4 +33,4 @@
 ^templates$
 ^test_full_example$
 ^TODO\.md$
-^staged_dependencies.yaml$
+^staged_dependencies\.yaml$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\.yaml$.

Dot was not escaped

