### PR TITLE
select & filter spec warnings

### DIFF
--- a/R/select_spec.R
+++ b/R/select_spec.R
@@ -186,7 +186,6 @@ select_spec.default <- function(choices,
       else
         selected <- selected[selected %in% choices]
     }
-    stopifnot(all(selected %in% choices))
     stopifnot(multiple || length(selected) == 1)
     if (is.null(names(selected))) {
       names(selected) <- as.character(selected)


### PR DESCRIPTION
close #136 

- removes wrongly specified column(s) in selected var with a warning
- if all are wrongly specified col names, then error

Reprex `select_spec`:
```
devtools::load_all(".../teal/.")

data_extract_spec(
  dataname = "ADTTE",
  select = select_spec(
    choices = c("AVAL", "BMRKR1", "AGE"),
        selected = c("TEST", "TEST1"),
        multiple = TRUE,
        fixed = FALSE,
        label = "Column"
    )
)
```