### PR TITLE
ci(.lintr): fixed a typo in .lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
 linters: with_defaults(line_length_linter = line_length_linter(120), cyclocomp_linter = NULL)
-error_on_lintr: TRUE
+error_on_lint: TRUE


### PR DESCRIPTION
Closes #175