### PR TITLE
fix(FilteredDataset.R): fixed documentation bug

### DIFF
--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -551,8 +551,8 @@ DefaultFilteredDataset <- R6::R6Class( # nolint
     #'
     #' @param id (`character(1)`)\cr
     #'   an ID string that corresponds with the ID used to call the module's UI function.
-    #' @param ... \cr
-    #'   Other arguments passed on to child `FilterStates` method.
+    #' @param ... other arguments passed on to child `FilterStates` methods.
+    #'
     #' @return `moduleServer` function which returns `NULL`
     srv_add_filter_state = function(id, ...) {
       check_ellipsis(..., stop = FALSE, allowed_args = "vars_include")

--- a/man/DefaultFilteredDataset.Rd
+++ b/man/DefaultFilteredDataset.Rd
@@ -151,8 +151,7 @@ contains single \code{FilterStates})
 \item{\code{id}}{(\code{character(1)})\cr
 an ID string that corresponds with the ID used to call the module's UI function.}
 
-\item{\code{...}}{\cr
-Other arguments passed on to child \code{FilterStates} method.}
+\item{\code{...}}{other arguments passed on to child \code{FilterStates} methods.}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
* fixed a bug where creating PDF files from the .Rd documentation would
fail because of a TeX syntax error
Closes #252

Test by running `rcmdcheck::rcmdcheck()` on r.roche.com or the newest integration docker image: registry.code.roche.com/nest/automation/docker_images/rocker/nestdeps:devel-4.1.0-2021_07_29-latest

There should be no warnings and errors now in the log.