### PR TITLE
cdisc_datasets primary keys updated

### DIFF
--- a/inst/cdisc_datasets/cdisc_datasets.yaml
+++ b/inst/cdisc_datasets/cdisc_datasets.yaml
@@ -34,7 +34,7 @@ ADEX:
   parent: "ADSL"
 
 ADLB:
-  primary: ["STUDYID", "USUBJID", "PARAMCD", "AVISITN", "ATPTN", "DTYPE", "ADTM", "BSEQ", "ASPID"]
+  primary: ["STUDYID", "USUBJID", "PARAMCD", "AVISITN", "ATPTN", "DTYPE", "ADTM", "LBSEQ", "ASPID"]
   foreign: ["STUDYID", "USUBJID"]
   parent: "ADSL"
 


### PR DESCRIPTION
closes insightsengineering/coredev-tasks#336

Some unit tests failed at `test-delayed_data_loading`. 

**Example: Test from line 115** 

![image](https://user-images.githubusercontent.com/87760125/134922864-ec06e426-c8f0-4b8c-9ce3-cd72c7a6d843.png)

The thing here is that `RSSEQ` would be now one of the primary keys, but this is not reflected in `expected_result`, which is a `data_extract_spec` object. 

@gogonzo I see you are also assigned to this issue. 