### PR TITLE
260 no filters@pre release

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -686,6 +686,10 @@ FilteredData <- R6::R6Class( # nolint
               active_datanames()
             }
 
+            if (length(datanames) == 0) {
+              return(NULL)
+            }
+
             datasets_df <- self$get_filter_overview(datanames = datanames)
 
             body_html <- lapply(


### PR DESCRIPTION
These 2 together should close https://github.com/insightsengineering/coredev-tasks/issues/13 
- [x] Review current PR
- [x] Review [this PR](https://code.roche.com/nest/docs/agile-R/-/merge_requests/14)

These 2 PRs together remove the printing and warnings shown here:
![image](https://user-images.githubusercontent.com/15201933/135063720-09c0d4ca-7cdb-4f47-97a7-12779d93a312.png)

But do not fix the `Warning in chunks$eval()`  @pawelru  - should we be digging into teal.goshawk to fix them? If so I suggest getting these 2 in first and putting a separate ticket in teal.goshawk for that.

Test with goshawk sample app in second PR. I tested on BEE

For this PR:
min reprex

```
devtools::load_all()
app <- init(
  data = teal:::get_dummy_cdisc_data(),
  modules = root_modules(
    module(
      "Source Data",
      server = function(input, output, session, datasets) {},
      ui = function(id, ...) {"test"},
      filters = NULL
    )
  ),
  header = tags$h1("Sample App")
)
shinyApp(app$ui, app$server)
```