### PR TITLE
add extra null check

### DIFF
--- a/R/FilteredData.R
+++ b/R/FilteredData.R
@@ -688,16 +688,19 @@ FilteredData <- R6::R6Class( # nolint
 
             datasets_df <- self$get_filter_overview(datanames = datanames)
 
-            body_html <- lapply(
-              seq_len(nrow(datasets_df)),
-              function(x) {
-                tags$tr(
-                  tags$td(rownames(datasets_df)[x]),
-                  tags$td(datasets_df[x, 1]),
-                  tags$td(datasets_df[x, 2])
-                )
-              }
-            )
+            body_html <- NULL
+            if (!is.null(datasets_df)) {
+              body_html <- lapply(
+                seq_len(nrow(datasets_df)),
+                function(x) {
+                  tags$tr(
+                    tags$td(rownames(datasets_df)[x]),
+                    tags$td(datasets_df[x, 1]),
+                    tags$td(datasets_df[x, 2])
+                  )
+                }
+              )
+            }
 
             header_html <- tags$tr(
               tags$td(""),


### PR DESCRIPTION
Will close https://github.com/insightsengineering/coredev-tasks/issues/13

- [ ] Review current PR 
- [ ] Review [this PR](https://code.roche.com/nest/docs/agile-R/-/merge_requests/14)

These 2 PRs together remove the printing and warnings shown here:
![image](https://user-images.githubusercontent.com/15201933/135063720-09c0d4ca-7cdb-4f47-97a7-12779d93a312.png)

But do not fix the `Warning in chunks$eval()`  @pawelru  - should we be digging into teal.goshawk to fix them? If so I suggest getting these 2 in first and putting a separate ticket in teal.goshawk for that.

Test with goshawk sample app in second PR. I tested on BEE

This PR fixes the symptom caused by the fact `datasets_df` can (whilst resolving reactivity)  be `NULL`. 

Instead of this fix we could fix it by returning `matrix(data = character(0), nrow = 0)` from `get_filter_overview` if `do.call(rbind, rows)` is NULL, but neither of these fix the fundamental reactivity issue in teal...which feels like a much bigger job...
 
 