### PR TITLE
ignore ... for MAEFIlteredDataset

### DIFF
--- a/R/FilteredDataset.R
+++ b/R/FilteredDataset.R
@@ -892,7 +892,6 @@ MAEFilteredDataset <- R6::R6Class( # nolint
     #' @param ... ignored.
     #' @return `moduleServer` function which returns `NULL`
     srv_add_filter_state = function(id, ...) {
-      check_ellipsis(..., stop = FALSE)
       moduleServer(
         id = id,
         function(input, output, session) {


### PR DESCRIPTION
Closes #269 

In FilteredData there is a call to `FilteredDataset$srv_add_filter_state` and `vars_include` is always passed no matter which dataset class is used
```r
fdataset$srv_add_filter_state(
  id = private$get_ui_add_filter_id(dataname),
  vars_include = self$get_filterable_varnames(dataname)
 )
```

In `MAEFilteredDataset$srv_add_filter_state` there was `check_ellipsis(...)` which returned the warning as `vars_include` was always passed. Because `...` is ignored we shouldn't check what is in the ellipsis.
```r
 #' @param ... ignored.
srv_add_filter_state = function(id, ...) {
 check_ellipsis(..., stop = FALSE)
```

Run the example
```r
devtools::load_all("../teal")
devtools::load_all("../teal.modules.hermes")

mae <- hermes::multi_assay_experiment
adtte <- scda::synthetic_cdisc_data("rcd_2021_07_07")$adtte %>%
  dplyr::mutate(CNSR = as.logical(CNSR))


app <- init(
  data = teal_data(
    dataset(
      "ADTTE",
      adtte,
      code = 'adtte <- radtte(cached = TRUE) %>% mutate(CNSR = as.logical(CNSR))'
    ),
    dataset("mae", mae)
  ),
  modules = list(
    tm_g_km(
      label = "KM PLOT",
      adtte_name = "ADTTE",
      mae_name = "mae",
      strata_var = c("SEX", "STRATA1")
    )
  )
)

shinyApp(ui = app$ui, server = app$server)
```