### PR TITLE
Add sets for TESTING_DEPTH 

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -171,7 +171,7 @@ jobs:
 # TODO: if configurable then --as-cran optionally
       - name: Run R CMD CHECK
         run: |
-          if [[ -z "${NO_TESTS}" ]]; then
+          if [[ -z "${{ env.NO_TESTS }}" ]]; then
             R CMD check ${{ env.PKGBUILD }}
           else
             R CMD check --no-tests ${{ env.PKGBUILD }}


### PR DESCRIPTION
Related to: insightsengineering/automation-tasks#41

Default TESTING_DEPTH = 1
For PR TESTING_DEPTH = 3
If commit (last/the newest commit) message contains: `[skip tests] <your message>`,  R CMD check starts with --no-tests option