### PR TITLE
devops: removed test.nest dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,6 @@ Suggests:
     rmarkdown,
     scda,
     scda.2021,
-    test.nest (>= 0.2.11),
     testthat (>= 2.0),
     withr
 VignetteBuilder:

--- a/R/log_app_usage.R
+++ b/R/log_app_usage.R
@@ -104,7 +104,7 @@ line_usage_log <- function(...) {
 #' }
 line_pkg_log <- function(fields) {
   nest_packages <- c(
-    "test.nest", "utils.nest", "rtables", "hermes", "teal.modules.hermes",
+    "utils.nest", "rtables", "hermes", "teal.modules.hermes",
     "tern", "teal", "teal.devel", "teal.modules.general", "teal.modules.clinical",
     "osprey", "teal.osprey", "goshawk", "teal.goshawk")
   pkg_desc <- utils::sessionInfo()$otherPkgs

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -14,9 +14,6 @@ upstream_repos:
   insightsengineering/scda.2021:
     repo: insightsengineering/scda.2021
     host: https://github.com
-  insightsengineering/test.nest:
-    repo: insightsengineering/test.nest
-    host: https://github.com
 downstream_repos:
   insightsengineering/teal.devel:
     repo: insightsengineering/teal.devel

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -1,1 +1,0 @@
-test.nest::test_all()


### PR DESCRIPTION
Related to insightsengineering/coredev-tasks#70
