### PR TITLE
docs: changed the vignette engine of vignettes/teal_options.R

### DIFF
--- a/vignettes/teal_options.Rmd
+++ b/vignettes/teal_options.Rmd
@@ -6,7 +6,7 @@ output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Modifying a Teal application with R options}
   %\VignetteEncoding{UTF-8}
-  %\VignetteEngine{knitr::knitr}
+  %\VignetteEngine{knitr::rmarkdown}
 editor_options:
   chunk_output_type: console
 ---


### PR DESCRIPTION
Closes #455

There is a false positive note about an undeclared import in `teal_options`. Fact is, the vignette does not call any of the functions from teal.devel, just references them in backticks.