### PR TITLE
deprecate bookmarking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # teal 0.11.0.9005
 
+### Breaking changes
+* Deprecated `bookmarkableShinyApp`. In future releases the `teal` framework will stop supporting shiny bookmarking (which has not officially been supported); it may be officially supported in the future. Note the filter panel in `teal.slice` retains its ability to save and restore its state if used in a standalone `shiny` app with bookmarking. 
+
 ### Miscellaneous
 * Added a template to the `pkgdown` configuration.
 * Removed unneeded `shinytest` app tests.

--- a/R/init.R
+++ b/R/init.R
@@ -86,7 +86,6 @@
 #'     )
 #'   )
 #'   ```
-#'   `filter` is ignored if the app is restored from a bookmarked state.
 #' @param header (`character` or `shiny.tag`) \cr
 #'   the header of the app. Note shiny code placed here (and in the footer
 #'   argument) will be placed in the app's `ui` function so code which needs to be placed in the `ui` function
@@ -144,8 +143,6 @@
 #' )
 #' \dontrun{
 #' shinyApp(app$ui, app$server)
-#' # or: to also work with bookmarking
-#' bookmarkableShinyApp(app$ui, app$server)
 #' }
 #'
 #' # See the vignette for an example how to embed this app as a module
@@ -193,7 +190,9 @@ init <- function(data,
 
 #' Make a Shiny UI function bookmarkable
 #'
-#' @description `r lifecycle::badge("experimental")`
+#' @description `r lifecycle::badge("deprecated")`
+#'
+#' This function is deprecated and will be removed in a future release of `teal`.
 #'
 #' This is a customization of `shinyApp`.
 #'
@@ -231,6 +230,15 @@ init <- function(data,
 #' @return `shinyApp` value
 #' @export
 bookmarkableShinyApp <- function(ui, server, ...) { # nolint
+
+  # Note when this function is removed code to allow bookmarking in srv_teal
+  # should also be removed.
+  lifecycle::deprecate_soft(
+    when = "0.12.0",
+    what = "bookmarkableShinyApp()",
+    details = "In future releases teal will stop supporting shiny bookmarking"
+  )
+
   # ui must be a function of request to be bookmarkable
   ui_new <- function(request) {
     # we use similar logic to `shiny:::uiHttpHandler`

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -15,8 +15,6 @@
 #' for non-delayed data which takes time to load into memory, avoiding
 #' Shiny session timeouts.
 #'
-#' Bookmarking is supported, i.e. the datasets filter state that this class
-#' is responsible for is stored in and restored from the bookmarked state.
 #'
 #' It is written as a Shiny module so it can be added into other apps as well.
 #'
@@ -115,8 +113,6 @@ ui_teal <- function(id,
 #' The currently active tab is tracked and the right filter panel
 #' updates the displayed datasets to filter for according to the active datanames
 #' of the tab.
-#' The initially displayed filter states can be provided, bookmarked filter
-#' states always take precedence over them.
 #'
 #' For more doc, see [ui_teal()].
 #'
@@ -151,9 +147,11 @@ srv_teal <- function(id, modules, raw_data, filter = list()) {
     )
 
     # bookmarking -----
+    # Note bookmarkableShinyApp has been soft deprecated and when it has been removed completely
+    # this code should be removed.
     saved_datasets_state <- reactiveVal(NULL) # set when restored because data must already be populated
     onBookmark(function(state) {
-      # this function is isolated  by Shiny
+      # this function is isolated by Shiny
       # We store the entire R6 class with reactive values in it, but set the data to NULL.
       # Note that we cannnot directly do this on datasets as this would trigger
       # reactivity to recompute the filtered datasets, which is not needed.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,7 +13,6 @@ reference:
   - title: Teal Core Functions
     desc: These are the main functions needed to build a teal app.
     contents:
-      - bookmarkableShinyApp
       - init
       - module
       - modules
@@ -38,3 +37,6 @@ reference:
       - get_rcode_srv
       - get_rcode_ui
       - show_rcode_modal
+  - title: Deprecated function
+    contents:
+      - bookmarkableShinyApp

--- a/man/bookmarkableShinyApp.Rd
+++ b/man/bookmarkableShinyApp.Rd
@@ -19,7 +19,9 @@ one argument (\code{request})}
 \code{shinyApp} value
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+This function is deprecated and will be removed in a future release of \code{teal}.
 
 This is a customization of \code{shinyApp}.
 

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -81,9 +81,7 @@ different way. Since it contains patient data with list of experiments,
     )
   )
 )
-}
-
-\code{filter} is ignored if the app is restored from a bookmarked state.}
+}}
 
 \item{header}{(\code{character} or \code{shiny.tag}) \cr
 the header of the app. Note shiny code placed here (and in the footer
@@ -150,8 +148,6 @@ app <- init(
 )
 \dontrun{
 shinyApp(app$ui, app$server)
-# or: to also work with bookmarking
-bookmarkableShinyApp(app$ui, app$server)
 }
 
 # See the vignette for an example how to embed this app as a module

--- a/man/srv_tabs_with_filters.Rd
+++ b/man/srv_tabs_with_filters.Rd
@@ -71,9 +71,7 @@ different way. Since it contains patient data with list of experiments,
     )
   )
 )
-}
-
-\code{filter} is ignored if the app is restored from a bookmarked state.}
+}}
 }
 \value{
 \code{reactive} currently selected active_module

--- a/man/srv_teal.Rd
+++ b/man/srv_teal.Rd
@@ -70,9 +70,7 @@ different way. Since it contains patient data with list of experiments,
     )
   )
 )
-}
-
-\code{filter} is ignored if the app is restored from a bookmarked state.}
+}}
 }
 \value{
 \code{reactive} which returns the currently active module
@@ -85,8 +83,6 @@ main teal UI that depends on the data.
 The currently active tab is tracked and the right filter panel
 updates the displayed datasets to filter for according to the active datanames
 of the tab.
-The initially displayed filter states can be provided, bookmarked filter
-states always take precedence over them.
 }
 \details{
 For more doc, see \code{\link[=ui_teal]{ui_teal()}}.

--- a/man/srv_teal_with_splash.Rd
+++ b/man/srv_teal_with_splash.Rd
@@ -77,9 +77,7 @@ different way. Since it contains patient data with list of experiments,
     )
   )
 )
-}
-
-\code{filter} is ignored if the app is restored from a bookmarked state.}
+}}
 }
 \value{
 \code{reactive}, return value of \code{\link[=srv_teal]{srv_teal()}}

--- a/man/ui_teal.Rd
+++ b/man/ui_teal.Rd
@@ -49,9 +49,6 @@ The splash screen functionality can also be used
 for non-delayed data which takes time to load into memory, avoiding
 Shiny session timeouts.
 
-Bookmarking is supported, i.e. the datasets filter state that this class
-is responsible for is stored in and restored from the bookmarked state.
-
 It is written as a Shiny module so it can be added into other apps as well.
 }
 \examples{


### PR DESCRIPTION
Closes #502 

Note there's lots of bookmarking code in `srv_teal` which cannot be removed until `bookmarkableShinyApp` is completely removed.
