### PR TITLE
Update font awesome icon labels for FA 6

### DIFF
--- a/R/include_css_js.R
+++ b/R/include_css_js.R
@@ -77,6 +77,6 @@ include_teal_css_js <- function() {
     include_css_files(),
     # init.js is executed from the server
     include_js_files(except = "init.js"),
-    shinyjs::hidden(icon("cog")), # add hidden icon to load font-awesome css for icons
+    shinyjs::hidden(icon("gear")), # add hidden icon to load font-awesome css for icons
   )
 }

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -82,7 +82,7 @@ ui_teal <- function(id,
   shiny_busy_message_panel <- conditionalPanel(
     condition = "(($('html').hasClass('shiny-busy')) && (document.getElementById('shiny-notification-panel') == null))", # nolint
     div(
-      icon("sync", "spin fa-spin"),
+      icon("arrows-rotate", "spin fa-spin"),
       "Computing ...",
       # CSS defined in `custom.css`
       class = "shinybusymessage"


### PR DESCRIPTION
Update font awesome icon labels for FA 6, to avoid warnings like:

```
This Font Awesome icon ('some icon') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```