### PR TITLE
Add sessionInfo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     teal.logger (>= 0.1.1),
     teal.reporter (>= 0.1.1),
     teal.slice (>= 0.2.0),
+    teal.widgets (>= 0.2.0),
     utils
 Suggests:
     bslib,
@@ -50,7 +51,6 @@ Suggests:
     rmarkdown,
     scda (>= 0.1.5),
     scda.2022 (>= 0.1.3),
-    teal.widgets (>= 0.2.0),
     testthat (>= 2.0),
     withr,
     yaml

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # teal 0.12.0.9001
 
 * Updated examples to use `scda.2022`.
+* Added R session information into a link in the footer of `teal` applications.
 
 # teal 0.12.0
 

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -101,7 +101,7 @@ ui_teal <- function(id,
     tags$footer(
       div(
         footer,
-        teal.widgets::verbatim_popup_ui(ns("sessionInfo"), "Session Info", type ="link"),
+        teal.widgets::verbatim_popup_ui(ns("sessionInfo"), "Session Info", type = "link"),
         textOutput(ns("identifier"))
       )
     )

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -98,7 +98,13 @@ ui_teal <- function(id,
     shiny_busy_message_panel,
     splash_ui,
     tags$hr(),
-    tags$footer(div(footer, textOutput(ns("identifier"))))
+    tags$footer(
+      div(
+        footer,
+        teal.widgets::verbatim_popup_ui(ns("sessionInfo"), "Session Info", type ="link"),
+        textOutput(ns("identifier"))
+      )
+    )
   )
   return(res)
 }
@@ -128,6 +134,12 @@ srv_teal <- function(id, modules, raw_data, filter = list()) {
 
     output$identifier <- renderText(
       paste0("Pid:", Sys.getpid(), " Token:", substr(session$token, 25, 32))
+    )
+
+    teal.widgets::verbatim_popup_srv(
+      "sessionInfo",
+      verbatim_content = utils::capture.output(utils::sessionInfo()),
+      title = "SessionInfo"
     )
 
     # Javascript code


### PR DESCRIPTION
This fixes the first part of https://github.com/insightsengineering/teal/issues/752

Requires https://github.com/insightsengineering/teal.widgets/pull/100

Test with:

```
library(teal)

app <- init(
  data = teal_data(
    dataset("MTCARS", mtcars)
  ),
  modules = modules(example_module())
)

shinyApp(app$ui, app$server)
```

![image](https://user-images.githubusercontent.com/15201933/198269009-81675fed-aa2e-4f47-bccc-04e43baae513.png)
![image](https://user-images.githubusercontent.com/15201933/198269077-8a9e2af5-cd40-4207-975a-5a4e1a8c6f6f.png)

