### PR TITLE
Fix failing test

### DIFF
--- a/tests/testthat/test-module_nested_tabs.R
+++ b/tests/testthat/test-module_nested_tabs.R
@@ -315,13 +315,8 @@ testthat::test_that(".datasets_to_data returns tdata object", {
   testthat::expect_equal(
     isolate(get_code(data)),
     c(
-      "# Add any code to install/load your NEST environment here",
-      paste0(
-        "library(testthat)\nlibrary(shiny)\nlibrary(teal.data)\nlibrary(magrittr)\nlibrary(teal.transform)\n",
-        "library(teal)\nlibrary(matrixStats)\nlibrary(MatrixGenerics)\nlibrary(BiocGenerics)\nlibrary(S4Vectors)\n",
-        "library(IRanges)\nlibrary(GenomeInfoDb)\nlibrary(GenomicRanges)\nlibrary(Biobase)\n",
-        "library(SummarizedExperiment)\nlibrary(MultiAssayExperiment)"
-      ),
+      get_rcode_str_install(),
+      get_rcode_libraries(),
       "d1 <- data.frame(id = 1:5, pk = c(2, 3, 2, 1, 4), val = 1:5)\nd2 <- data.frame(id = 1:5, value = 1:5)\n\n",
       paste0(
         "stopifnot(rlang::hash(d1) == \"f6f90d2c133ca4abdeb2f7a7d85b731e\")\n",

--- a/tests/testthat/test-rcode_utils.R
+++ b/tests/testthat/test-rcode_utils.R
@@ -96,3 +96,13 @@ testthat::test_that("With teal.load_nest_code option is not character get_rcode_
     testthat::expect_equal(get_rcode_str_install(), "# Add any code to install/load your NEST environment here")
   )
 })
+
+
+testthat::test_that("get_rcode_libraries returns current session packages", {
+  testthat::expect_true(
+    setequal(
+      strsplit(gsub("library\\(|\\)", "", get_rcode_libraries()), "\n")[[1]],
+      vapply(sessionInfo()$otherPkgs, FUN = `[[`, index = "Package", FUN.VALUE = character(1), USE.NAMES = FALSE)
+    )
+  )
+})


### PR DESCRIPTION
Fixes test failure on the environment where packages loads in a different order. We can't expect that the environment everywhere will have the same packages versions and thus the same dependencies. There is high chance that packages will be loaded in different order (according to dependency tree). This is why we can't fix the order of packages but test has to be "dynamic"  