### PR TITLE
835 - get_rcode_*() starts new code chunks in newlines

### DIFF
--- a/R/get_rcode.R
+++ b/R/get_rcode.R
@@ -162,7 +162,7 @@ get_datasets_code <- function(datanames, datasets, hashes) {
       ),
       collapse = "\n"
     )
-    str_code <- paste0(str_code, "\n\n", check_note_string)
+    str_code <- paste0(str_code, "\n\n", check_note_string, "\n\n")
   }
 
   str_hash <- paste(

--- a/R/get_rcode_utils.R
+++ b/R/get_rcode_utils.R
@@ -48,7 +48,11 @@ get_rcode_libraries <- function() {
   ) %>%
     # put it into reverse order to correctly simulate executed code
     rev() %>%
-    paste0(collapse = "\n")
+    paste0(sep = "\n") %>%
+    paste0(collapse = "")
+    # motivation: second one does not have '\n' at the end which is needed
+    # letters[1:5] %>% paste0(sep = "\n") %>% paste0(collapse = "")
+    # letters[1:5] %>% paste0(collapse = "\n")
 }
 
 
@@ -60,7 +64,7 @@ get_rcode_str_install <- function() {
     return(code_string)
   }
 
-  return("# Add any code to install/load your NEST environment here")
+  return("# Add any code to install/load your NEST environment here\n")
 }
 
 #' Pads a string

--- a/tests/testthat/test-rcode_utils.R
+++ b/tests/testthat/test-rcode_utils.R
@@ -1,7 +1,7 @@
 testthat::test_that("With no teal.load_nest_code option set get_rcode_str_install returns default string", {
   withr::with_options(
     list(teal.load_nest_code = NULL),
-    testthat::expect_equal(get_rcode_str_install(), "# Add any code to install/load your NEST environment here")
+    testthat::expect_equal(get_rcode_str_install(), "# Add any code to install/load your NEST environment here\n")
   )
 })
 
@@ -24,13 +24,13 @@ testthat::test_that("With teal.load_nest_code option is not character get_rcode_
           default string", {
   withr::with_options(
     list(teal.load_nest_code = TRUE),
-    testthat::expect_equal(get_rcode_str_install(), "# Add any code to install/load your NEST environment here")
+    testthat::expect_equal(get_rcode_str_install(), "# Add any code to install/load your NEST environment here\n")
   )
 
 
   withr::with_options(
     list(teal.load_nest_code = list(x = "boo")),
-    testthat::expect_equal(get_rcode_str_install(), "# Add any code to install/load your NEST environment here")
+    testthat::expect_equal(get_rcode_str_install(), "# Add any code to install/load your NEST environment here\n")
   )
 })
 


### PR DESCRIPTION
This is an answer to #835 

Before the change

<img width="493" alt="Capture1" src="https://github.com/insightsengineering/teal/assets/133694481/04e7fbbd-733a-4f43-9991-f6a753f846a1">

After the change

<img width="495" alt="capture2" src="https://github.com/insightsengineering/teal/assets/133694481/da24104d-eab3-4e7e-a9ab-a5f6cdcb0d13">
