### PR TITLE
818 documentation cleanup

### DIFF
--- a/vignettes/adding-support-for-reporting.Rmd
+++ b/vignettes/adding-support-for-reporting.Rmd
@@ -226,7 +226,7 @@ To support `TealReportCard`, the function that is passed to `teal.reporter::simp
 
 ```{r}
 custom_function <- function(card = TealReportCard$new()) {
-  # ... some code ... # 
+  # ... some code ... #
   card
 }
 ```


### PR DESCRIPTION
Closes #818 

With this PR we aimed to explain `teal.code` usage in `Adding support for Reporting to custom modules` vignette. This vignette demonstrates the usage of `teal.reporter` modules with `teal` apps. The example with `teal.code` is not necessary for the vignette however it shows an advanced combination of usage of `teal.code` and `teal.reporter` hence I decided not to remove `teal.code` snippets from this article.

There are also `teal.code` snippets in another vignette (`Creating Custom Modules`), so removal from this one would not remove the Suggests dependency for the `teal.code` package anyway.

I also reviewed the text and tried to polish it. 

Lastly, there examples in `R/module_tabs_with_filters.R` were updated during  https://github.com/insightsengineering/teal/issues/870