### PR TITLE
add placeholders to managers

### DIFF
--- a/R/module_filter_manager.R
+++ b/R/module_filter_manager.R
@@ -157,6 +157,13 @@ filter_manager_srv <- function(id, filtered_data_list, filter) {
         mm[] <- lapply(mm, ifelse, yes = intToUtf8(9989), no = intToUtf8(10060))
         mm[] <- lapply(mm, function(x) ifelse(is.na(x), intToUtf8(128306), x))
         if (!is_module_specific) colnames(mm) <- "Global Filters"
+
+        # Display placeholder if no filters defined.
+        if (nrow(mm) == 0L) {
+          mm <- data.frame(`Filter manager` = "No filters specified.", check.names = FALSE)
+          rownames(mm) <- ""
+        }
+
         mm
       },
       align = paste(c("l", rep("c", length(filtered_data_list))), collapse = ""),

--- a/R/module_snapshot_manager.R
+++ b/R/module_snapshot_manager.R
@@ -227,7 +227,15 @@ snapshot_manager_srv <- function(id, slices_global, mapping_matrix, filtered_dat
 
     # Create table to display list of snapshots and their actions.
     output$snapshot_list <- renderUI({
-      lapply(rev(reactiveValuesToList(divs)), function(d) d)
+      rows <- lapply(rev(reactiveValuesToList(divs)), function(d) d)
+      if (length(rows) == 0L) {
+        div(
+          class = "snapshot_manager_placeholder",
+          "Snapshots will appear here."
+        )
+      } else {
+        rows
+      }
     })
   })
 }

--- a/inst/css/sidebar.css
+++ b/inst/css/sidebar.css
@@ -40,3 +40,6 @@ a.disabled {
   flex: 1 0 50px;
   padding: 0em 1em;
 }
+.snapshot_manager_placeholder {
+  margin-top: 1em;
+}


### PR DESCRIPTION
Fixes #883 

Placeholder signs are added to filter manager and snapshot manager for cases when no filters/snapshots are present.
