### PR TITLE
don't throw validation messages unnecessarily

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal 0.14.0.9001
 
+### Miscellaneous
+
+* Enhance a `module` validation checks so that it won't throw messages about `data` argument unnecessarily.
+
 # teal 0.14.0
 
 ### New features

--- a/R/modules.R
+++ b/R/modules.R
@@ -232,7 +232,7 @@ module <- function(label = "module",
     )
   }
 
-  if (!is.element("data", server_formals)) {
+  if (!is.element("data", server_formals) && !is.null(datanames)) {
     message(sprintf("module \"%s\" server function takes no data so \"datanames\" will be ignored", label))
     datanames <- NULL
   }


### PR DESCRIPTION
During rendering TLG-Catalog I noticed that each shiny app throws a message about `data` argument in the reporter previewer module. This fix aim to silent unnecessary messages

https://github.com/insightsengineering/tlg-catalog/actions/runs/5888144351/job/15968763355