### PR TITLE
910 Remove Report Previewer column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ### Miscellaneous
 
-* Enhance a `module` validation checks so that it won't throw messages about `data` argument unnecessarily.
+* Enhanced a `module` validation checks so that it won't throw messages about `data` argument unnecessarily.
+* Removed `Report previewer` module from mapping matrix display in filter manager.
 
 # teal 0.14.0
 

--- a/R/module_filter_manager.R
+++ b/R/module_filter_manager.R
@@ -165,9 +165,9 @@ filter_manager_srv <- function(id, filtered_data_list, filter) {
         }
 
         # Report Previewer will not be displayed.
-        mm[!grepl("Report previewer", names(mm))]
+        mm[names(mm) != "Report previewer"]
       },
-      align = paste(c("l", rep("c", sum(!grepl("Report previewer", names(filtered_data_list))))), collapse = ""),
+      align = paste(c("l", rep("c", sum(names(filtered_data_list) != "Report previewer"))), collapse = ""),
       rownames = TRUE
     )
 

--- a/R/module_filter_manager.R
+++ b/R/module_filter_manager.R
@@ -147,7 +147,6 @@ filter_manager_srv <- function(id, filtered_data_list, filter) {
         ifelse(state_ids_global %in% state_ids_allowed, states_active, NA)
       })
 
-      # mapping_smooth <- mapping_smooth[grep("Report previewer", names(mapping_smooth), invert = TRUE)]
       as.data.frame(mapping_smooth, row.names = state_ids_global, check.names = FALSE)
     })
 

--- a/R/module_filter_manager.R
+++ b/R/module_filter_manager.R
@@ -147,6 +147,7 @@ filter_manager_srv <- function(id, filtered_data_list, filter) {
         ifelse(state_ids_global %in% state_ids_allowed, states_active, NA)
       })
 
+      # mapping_smooth <- mapping_smooth[grep("Report previewer", names(mapping_smooth), invert = TRUE)]
       as.data.frame(mapping_smooth, row.names = state_ids_global, check.names = FALSE)
     })
 
@@ -164,9 +165,10 @@ filter_manager_srv <- function(id, filtered_data_list, filter) {
           rownames(mm) <- ""
         }
 
-        mm
+        # Report Previewer will not be displayed.
+        mm[!grepl("Report previewer", names(mm))]
       },
-      align = paste(c("l", rep("c", length(filtered_data_list))), collapse = ""),
+      align = paste(c("l", rep("c", sum(!grepl("Report previewer", names(filtered_data_list))))), collapse = ""),
       rownames = TRUE
     )
 

--- a/R/modules.R
+++ b/R/modules.R
@@ -212,7 +212,18 @@ module <- function(label = "module",
   }
 
   if (label == "global_filters") {
-    stop("Label 'global_filters' is reserved in teal. Please change to something else.")
+    stop(
+      sprintf("module(label = \"%s\", ...\n  ", label),
+      "Label 'global_filters' is reserved in teal. Please change to something else.",
+      call. = FALSE
+    )
+  }
+  if (label == "Report previewer") {
+    stop(
+      sprintf("module(label = \"%s\", ...\n  ", label),
+      "Label 'Report previewer' is reserved in teal.",
+      call. = FALSE
+    )
   }
   server_formals <- names(formals(server))
   if (!(

--- a/R/reporter_previewer_module.R
+++ b/R/reporter_previewer_module.R
@@ -28,10 +28,11 @@ reporter_previewer_module <- function(label = "Report previewer", server_args = 
   }
 
   module <- module(
-    label = label,
+    label = "temporary label",
     server = srv, ui = ui,
     server_args = server_args, ui_args = list(), datanames = NULL
   )
   class(module) <- c("teal_module_previewer", class(module))
+  module$label <- label
   module
 }


### PR DESCRIPTION
Fixes #910 

The column named `"Report previewer"` is removed from the mapping matrix display.
Since the data.frame sent to `renderTable` potentially has one less column, the `align` argument is modified accordingly.

Additionally, `"Report previewer"` has been reserved as a module label during module creation, much like `"global_filters"`.
Since the actual previewer is supposed to have that label, it is set after the module is created.

This will only work as long as the name `"Report previewer"` does not change.
