### PR TITLE
adding regular expression to parse some edge cases.

### DIFF
--- a/R/ddl-run.R
+++ b/R/ddl-run.R
@@ -65,8 +65,13 @@ ddl_run <- function(input = list(),
   }
 
   code_strings <- vapply(code, deparse1, character(1L))
-  code_strings <- gsub("(input\\$)(\\w+)", "\\.(\\2\\)", code_strings)
-  code_strings <- gsub("(input\\[\\[\")(\\w+)(\"\\]\\])", "\\.(\\2\\)", code_strings)
+  # Replace input$ with .()
+  code_strings <- gsub("input\\$(\\w+\\.?\\w*)", "\\.(\\1)", code_strings)
+  code_strings <- gsub("(input\\$)(`[^`]+`)", "\\.(\\2)", code_strings)
+
+  # Replace input[[ with .()
+  code_strings <- gsub("(input\\[\\[\")(\\w+\\.?\\w*)(\"\\]\\])", "\\.(\\2\\)", code_strings)
+  code_strings <- gsub("(input\\[\\[\")(\\w+\\-\\w+)\"\\]\\]", ".(`\\2`)", code_strings)
 
   # Use bquote to obtain code with input values and masking values.
   as.expression(


### PR DESCRIPTION
The` .substitute_inputs` function substitute value for inputs either input$ or input[[, but problem occurs when variable names that contain periods or hyphens, such as `var.name `or` var-name` Although such variable names are unconventional but they are acceptable . To ensure that the `.substitute_inputs `function can work with a wider range of variable names, I have made adjustments to the regular expressions within the function so that it can correctly recognize and handle them. This will allow for adherence to R's flexible naming conventions without causing any errors during the substitution process.

for test regular expression
```

code_strings <- c("open_conn(username = input$username, username = input$use.rname, password = input$`pass-word`)",
                  "open_conn(username = input[[\"username\"]], password = input[[\"pass-word\"]])",
                  "open_conn(username = input$use.rname, password = input$`pass-word`)",
                  "open_conn(username = input[[\"use.rname\"]], password = input[[\"pass-word\"]])")

# Replace input$ with .()
code_strings <- gsub("input\\$(\\w+\\.?\\w*)", "\\.(\\1)", code_strings)
code_strings <- gsub("(input\\$)(`[^`]+`)", "\\.(\\2)", code_strings)

# Replace input[[ with .()
code_strings <- gsub("(input\\[\\[\")(\\w+\\.?\\w*)(\"\\]\\])", "\\.(\\2\\)", code_strings)
code_strings <- gsub("(input\\[\\[\")(\\w+\\-\\w+)\"\\]\\]", ".(`\\2`)", code_strings)
```