### PR TITLE
update repo roster link and pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
           - shiny
           - shinyjs
           - stats
+          - insightsengineering/teal.code
           - insightsengineering/teal.data
           - insightsengineering/teal.logger
           - insightsengineering/teal.reporter

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ This package is a result of a joint efforts by many developers and stakeholders.
 
 ### Stargazers
 
-[![Stargazers repo roster for @insightsengineering/teal](https://reporoster.com/stars/insightsengineering/teal)](https://github.com/insightsengineering/teal/stargazers)
+[![Stargazers repo roster for @insightsengineering/teal](http://reporoster.com/stars/insightsengineering/teal)](https://github.com/insightsengineering/teal/stargazers)
 
 ### Forkers
 
-[![Forkers repo roster for @insightsengineering/teal](https://reporoster.com/forks/insightsengineering/teal)](https://github.com/insightsengineering/teal/network/members)
+[![Forkers repo roster for @insightsengineering/teal](http://reporoster.com/forks/insightsengineering/teal)](https://github.com/insightsengineering/teal/network/members)


### PR DESCRIPTION
Related with #949, updating the link to `reporoster` in README.
Also updated the pre-commit config to include `teal.code`.
