### PR TITLE
1000 fix empty selection in restore

### DIFF
--- a/R/teal_slices-store.R
+++ b/R/teal_slices-store.R
@@ -63,7 +63,7 @@ slices_restore <- function(file) {
   tss_json$slices <-
     lapply(tss_json$slices, function(slice) {
       for (field in c("selected", "choices")) {
-        if (!is.null(slice[[field]])) {
+        if (length(slice[[field]]) > 0) {
           date_partial_regex <- "^[0-9]{4}-[0-9]{2}-[0-9]{2}"
           time_stamp_regex <- paste0(date_partial_regex, "\\s[0-9]{2}:[0-9]{2}:[0-9]{2}\\sUTC$")
 
@@ -75,6 +75,8 @@ slices_restore <- function(file) {
             } else {
               slice[[field]]
             }
+        } else {
+          slice[[field]] <- NULL
         }
       }
       slice

--- a/R/teal_slices-store.R
+++ b/R/teal_slices-store.R
@@ -76,7 +76,7 @@ slices_restore <- function(file) {
               slice[[field]]
             }
         } else {
-          slice[[field]] <- NULL
+          slice[[field]] <- character(0)
         }
       }
       slice

--- a/R/teal_slices-store.R
+++ b/R/teal_slices-store.R
@@ -63,25 +63,22 @@ slices_restore <- function(file) {
   tss_json$slices <-
     lapply(tss_json$slices, function(slice) {
       for (field in c("selected", "choices")) {
-        if (length(slice[[field]]) > 0) {
-          date_partial_regex <- "^[0-9]{4}-[0-9]{2}-[0-9]{2}"
-          time_stamp_regex <- paste0(date_partial_regex, "\\s[0-9]{2}:[0-9]{2}:[0-9]{2}\\sUTC$")
+        if (!is.null(slice[[field]])) {
+          if (length(slice[[field]]) > 0) {
+            date_partial_regex <- "^[0-9]{4}-[0-9]{2}-[0-9]{2}"
+            time_stamp_regex <- paste0(date_partial_regex, "\\s[0-9]{2}:[0-9]{2}:[0-9]{2}\\sUTC$")
 
-          slice[[field]] <-
-            if (all(grepl(paste0(date_partial_regex, "$"), slice[[field]]))) {
-              as.Date(slice[[field]])
-            } else if (all(grepl(time_stamp_regex, slice[[field]]))) {
-              as.POSIXct(slice[[field]], tz = "UTC")
-            } else {
-              slice[[field]]
-            }
-        } else {
-          slice[[field]] <-
-            if (field == "selected") {
-              character(0)
-            } else {
-              NULL
-            }
+            slice[[field]] <-
+              if (all(grepl(paste0(date_partial_regex, "$"), slice[[field]]))) {
+                as.Date(slice[[field]])
+              } else if (all(grepl(time_stamp_regex, slice[[field]]))) {
+                as.POSIXct(slice[[field]], tz = "UTC")
+              } else {
+                slice[[field]]
+              }
+          } else {
+            slice[[field]] <- character(0)
+          }
         }
       }
       slice

--- a/R/teal_slices-store.R
+++ b/R/teal_slices-store.R
@@ -76,7 +76,12 @@ slices_restore <- function(file) {
               slice[[field]]
             }
         } else {
-          slice[[field]] <- character(0)
+          slice[[field]] <-
+            if (field == "selected") {
+              character(0)
+            } else {
+              NULL
+            }
         }
       }
       slice

--- a/tests/testthat/test-teal_slices-store.R
+++ b/tests/testthat/test-teal_slices-store.R
@@ -1,3 +1,45 @@
+testthat::test_that("teal_slice store/restore supports NULL and character(0) for choices and selected", {
+  slices_path <- withr::local_file("slices.json")
+  tss <- teal_slices(
+    teal_slice(
+      dataname = "data",
+      varname = "var",
+      choices = character(0),
+      selected = NULL
+    )
+  )
+  slices_store(tss, slices_path)
+  tss_restored <- teal:::slices_restore("file.json")
+
+  slices2_path <- withr::local_file("slices2.json")
+  tss2 <- teal_slices(
+    teal_slice(
+      dataname = "data",
+      varname = "var",
+      choices = NULL,
+      selected = NULL
+    )
+  )
+  slices_store(tss2, slices2_path)
+  tss2_restored <- slices_restore(slices2_path)
+
+  slices3_path <- withr::local_file("slices3.json")
+  tss3 <- teal_slices(
+    teal_slice(
+      dataname = "data",
+      varname = "var",
+      choices = character(0),
+      selected = character(0)
+    )
+  )
+  slices_store(tss3, slices3_path)
+  tss3_restored <- slices_restore(slices3_path)
+
+  teal.slice:::expect_identical_slice(tss[[1]], tss_restored[[1]])
+  teal.slice:::expect_identical_slice(tss2[[1]], tss2_restored[[1]])
+  teal.slice:::expect_identical_slice(tss3[[1]], tss3_restored[[1]])
+})
+
 testthat::test_that("teal_slice store/restore supports saving `POSIXct` timestamps in selected", {
   slices_path <- withr::local_file("slices.json")
 

--- a/tests/testthat/test-teal_slices-store.R
+++ b/tests/testthat/test-teal_slices-store.R
@@ -9,7 +9,7 @@ testthat::test_that("teal_slice store/restore supports NULL and character(0) for
     )
   )
   slices_store(tss, slices_path)
-  tss_restored <- teal:::slices_restore("file.json")
+  tss_restored <- teal:::slices_restore(slices_path)
 
   slices2_path <- withr::local_file("slices2.json")
   tss2 <- teal_slices(


### PR DESCRIPTION
Closes #1000 

Hey, I fixed the issue with disability to load a snapshot with empty `selected` field.
This filter can now be created, saved and uploaded.

However on an upload of such filter and selection of such filter the app goes back to empty filters. Is that intended?


