### PR TITLE
Removes `library` calls from `get_rcode_libraries` in favor of manual specification

### DIFF
--- a/R/get_rcode_utils.R
+++ b/R/get_rcode_utils.R
@@ -5,17 +5,13 @@
 #' @return Character object contain code
 #' @keywords internal
 get_rcode_libraries <- function() {
-  vapply(
+  packages <- vapply(
     utils::sessionInfo()$otherPkgs,
-    function(x) {
-      paste0("library(", x$Package, ")")
-    },
+    function(x) paste0("library(", x$Package, ")"),
     character(1)
-  ) %>%
-    # put it into reverse order to correctly simulate executed code
-    rev() %>%
-    paste0(sep = "\n") %>%
-    paste0(collapse = "")
+  )
+  # put it into reverse order to correctly simulate executed code
+  paste(rev(packages), collapse = "\n")
 }
 
 

--- a/R/get_rcode_utils.R
+++ b/R/get_rcode_utils.R
@@ -8,10 +8,11 @@ get_rcode_libraries <- function(dataset_rcode) {
   packages <- rev(vapply(utils::sessionInfo()$otherPkgs, base::`[[`, character(1), "Package"))
 
   parsed_libraries <- if (!missing(dataset_rcode)) {
-    # Extract all lines with library()
-    #  TODO: remove strings first as this will pass "this is a string with library(something) in it"
+    # Extract all lines that start with library()
+    library_regex <- "(^l|.*<-|.*[ ;=\\({]l)ibrary\\(([[:alpha:]][[:alnum:].]*)\\)$"
+
     user_libraries <- Filter(
-      function(.x) grepl("(^l|.*<-|.*[ ;=\\({]l)ibrary\\(([a-z][[:alnum:].]*)\\)$", .x),
+      function(.x) grepl(library_regex, .x),
       # function(.x) grepl("library\\(.*\\)$", .x),
       vapply(strsplit(dataset_rcode, "\n")[[1]], trimws, character(1))
     )
@@ -19,7 +20,7 @@ get_rcode_libraries <- function(dataset_rcode) {
     # Keep only library name
     gsub(
       # library(...) must be located at beginning of line, or have a valid character before
-      "(^l|.*<-|.*[ ;=\\({]l)ibrary\\(([a-z][a-zA-Z0-9.]*)\\)$", "\\2",
+      library_regex, "\\2",
       # Strip out comments
       vapply(user_libraries, function(.x) as.character(str2expression(.x)), character(1L))
     )

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -292,7 +292,6 @@ srv_nested_tabs.teal_module <- function(id, datasets, modules, is_module_specifi
   code <- c(
     get_rcode_str_install(),
     loaded_libs,
-    "",
     dataset_rcode
   )
 

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -285,10 +285,15 @@ srv_nested_tabs.teal_module <- function(id, datasets, modules, is_module_specifi
 
   hashes <- calculate_hashes(datanames, datasets)
 
+  # list of code
+  dataset_rcode <- get_datasets_code(datanames, datasets, hashes)
+  loaded_libs <- get_rcode_libraries(dataset_rcode)
+
   code <- c(
     get_rcode_str_install(),
-    get_rcode_libraries(),
-    get_datasets_code(datanames, datasets, hashes)
+    loaded_libs,
+    "",
+    dataset_rcode
   )
 
   do.call(

--- a/man/get_rcode_libraries.Rd
+++ b/man/get_rcode_libraries.Rd
@@ -4,7 +4,7 @@
 \alias{get_rcode_libraries}
 \title{Generates library calls from current session info}
 \usage{
-get_rcode_libraries()
+get_rcode_libraries(dataset_rcode)
 }
 \value{
 Character object contain code

--- a/tests/testthat/test-rcode_utils.R
+++ b/tests/testthat/test-rcode_utils.R
@@ -34,13 +34,35 @@ testthat::test_that("With teal.load_nest_code option is not character get_rcode_
   )
 })
 
-
 testthat::test_that("get_rcode_libraries returns current session packages", {
-  testthat::expect_true(
-    setequal(
-      strsplit(gsub("library\\(|\\)", "", get_rcode_libraries()), "\n")[[1]],
-      vapply(sessionInfo()$otherPkgs, FUN = `[[`, index = "Package", FUN.VALUE = character(1), USE.NAMES = FALSE)
-    )
+  testthat::expect_setequal(
+    strsplit(gsub("library\\(|\\)", "", get_rcode_libraries()), "\n")[[1]],
+    vapply(sessionInfo()$otherPkgs, FUN = `[[`, index = "Package", FUN.VALUE = character(1))
+  )
+})
+
+testthat::test_that("get_rcode_libraries returns current session packages excluding testthat", {
+  # Make sure testthat is attached
+  require(testthat, quietly = TRUE)
+  testthat::expect_setequal(
+    setdiff(
+      vapply(sessionInfo()$otherPkgs, FUN = `[[`, index = "Package", FUN.VALUE = character(1)),
+      c(strsplit(gsub("library\\(|\\)", "", get_rcode_libraries("library(testthat)\n")), "\n")[[1]])
+    ),
+    "testthat"
+  )
+})
+
+testthat::test_that("get_rcode_libraries returns current session packages excluding testthat and teal", {
+  # Make sure testthat is attached
+  require(testthat, quietly = TRUE)
+  require(teal, quietly = TRUE)
+  testthat::expect_setequal(
+    setdiff(
+      vapply(sessionInfo()$otherPkgs, FUN = `[[`, index = "Package", FUN.VALUE = character(1)),
+      c(strsplit(gsub("library\\(|\\)", "", get_rcode_libraries("library(testthat)\nlibrary(teal)")), "\n")[[1]])
+    ),
+    c("testthat", "teal")
   )
 })
 


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #950

#### Changes description

- [x] Removes `library` calls if they are already manually specified by the app developer
  - [x] Ignore cases when `library(...)` is after a comment character (`#`)
  - [ ] Ignore cases when `library(...)` is written inside a string `var1 <- "a weird string with library(ggplot2)"`
- [ ] Show error when `loadedNamespaces` package is not installed in the user
  - Being discussed in issue
