### PR TITLE
Modifies tests as filter result uses a parent-child relationship by default

### DIFF
--- a/tests/testthat/test-module_nested_tabs.R
+++ b/tests/testthat/test-module_nested_tabs.R
@@ -371,7 +371,7 @@ testthat::test_that(".datasets_to_data returns data which is filtered", {
   d1_filtered <- data[["d1"]]
   testthat::expect_equal(d1_filtered, data.frame(id = 1:2, pk = 2:3, val = 1:2))
   d2_filtered <- data[["d2"]]
-  testthat::expect_equal(d2_filtered, data.frame(id = 1:5, value = 1:5))
+  testthat::expect_equal(d2_filtered, data.frame(id = 2:3, value = 2:3))
 })
 
 


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes https://github.com/insightsengineering/teal.slice/issues/502

Part of https://github.com/insightsengineering/teal.slice/pull/503 and https://github.com/insightsengineering/teal.data/pull/215

### Changes 

- Corrects test to reflect behavior resulting from `teal.data` default parent setting when creating new `join_key`