### PR TITLE
898 save app state version 4

### DIFF
--- a/R/GlobalSetter.R
+++ b/R/GlobalSetter.R
@@ -1,0 +1,94 @@
+#' Set global objects
+#'
+#' Class to manage global objects and bring them into scope of `shiny` modules.
+#'
+#' Singleton object to pass variables between modules. Instantiated in the package namespace.
+#' Global objects are stored in the `session$userData` environment.
+#' Every `shiny` module can register a setter functions for a global variable to be taken from storage
+#' or created from scratch. Then, that function can be called anywhere in the app.
+#'
+#' @docType class
+#' @name GlobalSetter
+#' @rdname GlobalSetter
+#'
+#' @examples
+#' GlobalSetter <- getFromNamespace("GlobalSetter", "teal")
+#' setter <- GlobalSetter$new()
+#' setter$add_setter("romans", function() {
+#'   assign("romans", .romans, envir = .GlobalEnv)
+#'   .romans
+#'   })
+#' setter
+#' setter$set_global("romans")
+#' exists("romans", envir = .GlobalEnv, inherits = TRUE)
+#'
+#' @keywords internal
+#'
+GlobalSetter <- R6::R6Class(
+  classname = "GlobalSetter",
+
+  # __Public Methods ----
+  public = list(
+
+    #' @description
+    #' Set object.
+    #' @param obj (`character(1)`) Name of object to set.
+    #' @return
+    #' Whatever the particular setter function returns, usually the global object.
+    set_global = function(obj) {
+      if (!shiny::isRunning()) {
+        message("no shiny, no objects")
+        return(NULL)
+      }
+      checkmate::assert_string(obj)
+      checkmate::assert_choice(obj, private$objects)
+
+      ind <- match(obj, private$objects)
+      private$functions[[ind]]()
+    },
+
+    #' @description
+    #' Add setter function for global object.
+    #' @param obj (`character(1)`) Name of object.
+    #' @param fun (`function`) Setter function.
+    add_setter = function(obj, fun) {
+      checkmate::assert_string(obj)
+      checkmate::assert_function(fun)
+
+      ind <- match(obj, private$objects, nomatch = length(private$objects) + 1L)
+
+      if (is.element(obj, private$objects)) {
+        if (identical(fun, private$functions[[ind]])) {
+          message("this setter already exists")
+          return(invisible(NULL))
+        } else {
+          message(sprintf("overwriting setter function for object '%s'", obj))
+        }
+      }
+
+      private$objects[ind] <- obj
+      private$functions[[ind]] <- fun
+      invisible(NULL)
+    },
+
+    #' @noRd
+    format = function(...) {
+      paste(
+        c(
+          "Global Object Setter",
+          if (length(private$objects)) sprintf("  objects: %s", toString(private$objects)) else "  empty"
+        ),
+        collapse = "\n"
+      )
+    }
+  ),
+
+  # __Private Members ----
+  private = list(
+    objects = character(0L), # objects for which setter functions have been defined
+    functions = list() # setter functions
+  ),
+  cloneable = FALSE
+)
+
+GS <- GlobalSetter$new()

--- a/R/module_filter_manager.R
+++ b/R/module_filter_manager.R
@@ -156,9 +156,9 @@ filter_manager_srv <- function(id, filtered_data_list, filter) {
     })
 
     # Call snapshot manager.
-    snapshot_history <- snapshot_manager_srv("snapshot_manager")
+    snapshot_manager_srv("snapshot_manager")
     # Call state manager.
-    state_manager_srv("state_manager", slices_global, mapping_matrix, filtered_data_list, snapshot_history)
+    state_manager_srv("state_manager")
 
     modules_out # returned for testing purpose
   })
@@ -273,7 +273,7 @@ create_mapping_matrix <- function(filtered_data_list, slices_global) {
 
 # ! this function is very impure, it depends on caller state and causes side effects in app session !
 set_intermodule_objects <- function(
-    obj = c("slices_global", "filtered_data_list", "mapping_matrix", "snapshot_history")
+    obj = c("slices_global", "filtered_data_list", "mapping_matrix", "snapshot_history", "grab_history")
 ) {
 
   obj <- match.arg(obj)
@@ -325,6 +325,16 @@ set_intermodule_objects <- function(
         })
       } else {
         sesh$userData$snapshot_history
+      }
+    },
+
+    "grab_history" = {
+      if (is.null(sesh$userData$grab_history)) {
+        sesh$userData$grab_history <- reactiveVal({
+          list()
+        })
+      } else {
+        sesh$userData$grab_history
       }
     }
 

--- a/R/module_filter_manager.R
+++ b/R/module_filter_manager.R
@@ -113,25 +113,22 @@ filter_manager_srv <- function(id, filtered_data_list, filter) {
 
     is_module_specific <- isTRUE(attr(filter, "module_specific"))
 
+    # Register setters for global objects
     GS$add_setter("slices_global", setter_slices_global)
     GS$add_setter("filtered_data_list", setter_filtered_data_list)
     GS$add_setter("mapping_matrix", setter_mapping_matrix)
 
+    # Create global list of slices.
+    # Contains all available teal_slice objects available to all modules.
+    # Passed whole to instances of FilteredData used for individual modules.
+    # Down there a subset that pertains to the data sets used in that module is applied and displayed.
     slices_global <- GS$set_global("slices_global")
+    # Prepare FilteredData object according to app type (global/module-specific).
     filtered_data_list <- GS$set_global("filtered_data_list")
+    # Represent mapping of modules to filters.
     mapping_matrix <- GS$set_global("mapping_matrix")
-
-    # # Create global list of slices.
-    # # Contains all available teal_slice objects available to all modules.
-    # # Passed whole to instances of FilteredData used for individual modules.
-    # # Down there a subset that pertains to the data sets used in that module is applied and displayed.
-    # slices_global <- set_intermodule_objects("slices_global")
-    # # Prepare FilteredData object according to app type (global/module-specific).
-    # filtered_data_list <- set_intermodule_objects("filtered_data_list")
-    # # Represent mapping of modules to filters.
-    # mapping_matrix <- set_intermodule_objects("mapping_matrix")
-    # # The three objects above are also stored in the app session's userData.
-    # # They will be used in other modules and stored when bookmarking.
+    # The three objects above are also stored in the app session's userData.
+    # They will be used in other modules and stored when bookmarking.
 
     output$slices_table <- renderTable(
       expr = {
@@ -290,75 +287,6 @@ create_mapping_matrix <- function(filtered_data_list, slices_global) {
 }
 
 
-# # ! this function is very impure, it depends on caller state and causes side effects in app session !
-# set_intermodule_objects <- function(
-#     obj = c("slices_global", "filtered_data_list", "mapping_matrix", "snapshot_history", "grab_history")
-# ) {
-#
-#   obj <- match.arg(obj)
-#   sesh <- get_master_session()
-#
-#   switch(
-#     obj,
-#
-#     "slices_global" = { # `reactiveVal`
-#       # restored from session OR created from filter and stored in session
-#       if (is.null(sesh$userData$slices_global)) {
-#         filter <- dynGet("filter")
-#         sesh$userData$slices_global <- reactiveVal(filter)
-#       } else {
-#         sesh$userData$slices_global
-#       }
-#     },
-#
-#     "filtered_data_list" = { # list of `FilteredData`
-#       # restored from session OR created from filtered_data_list and is_module_specific and stored in session
-#       if (is.null(sesh$userData$filtered_data_list)) {
-#         filtered_data_list <- dynGet("filtered_data_list")
-#         is_module_specific <- dynGet("is_module_specific")
-#         sesh$userData$filtered_data_list <- create_filtered_data_list(filtered_data_list, is_module_specific)
-#       } else {
-#         sesh$userData$filtered_data_list
-#       }
-#     },
-#
-#     "mapping_matrix" = { # `reactive`
-#       # restored from session OR created from filtered_data_list and slices global and stored in session
-#       if (is.null(sesh$userData$mapping_matrix)) {
-#         filtered_data_list <- dynGet("filtered_data_list")
-#         slices_global <- dynGet("slices_global")
-#         sesh$userData$mapping_matrix <- create_mapping_matrix(filtered_data_list, slices_global)
-#       } else {
-#         sesh$userData$mapping_matrix
-#       }
-#     },
-#
-#     "snapshot_history" = { # `reactiveVal`
-#       # restored from session OR created from slices_global and stored in session
-#       if (is.null(sesh$userData$snapshot_history)) {
-#         slices_global <- dynGet("slices_global")
-#         sesh$userData$snapshot_history <- reactiveVal({
-#           list(
-#             "Initial application state" = as.list(isolate(slices_global()), recursive = TRUE)
-#           )
-#         })
-#       } else {
-#         sesh$userData$snapshot_history
-#       }
-#     },
-#
-#     "grab_history" = {
-#       if (is.null(sesh$userData$grab_history)) {
-#         sesh$userData$grab_history <- reactiveVal({
-#           list()
-#         })
-#       } else {
-#         sesh$userData$grab_history
-#       }
-#     }
-#
-#   )
-# }
 
 # setter for global variable ----
 #' @keywords internal

--- a/R/module_snapshot_manager.R
+++ b/R/module_snapshot_manager.R
@@ -102,24 +102,18 @@ snapshot_manager_ui <- function(id) {
 #' @rdname snapshot_manager_module
 #' @keywords internal
 #'
-snapshot_manager_srv <- function(id, slices_global, mapping_matrix, filtered_data_list) {
+snapshot_manager_srv <- function(id) {
   checkmate::assert_character(id)
-  checkmate::assert_true(is.reactive(slices_global))
-  checkmate::assert_class(isolate(slices_global()), "teal_slices")
-  checkmate::assert_true(is.reactive(mapping_matrix))
-  checkmate::assert_data_frame(isolate(mapping_matrix()), null.ok = TRUE)
-  checkmate::assert_list(filtered_data_list, types = "FilteredData", any.missing = FALSE, names = "named")
 
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
+    # Retrieve intermodule objects ----
+    slices_global <- set_intermodule_objects("slices_global")
+    filtered_data_list <- set_intermodule_objects("filtered_data_list")
+    mapping_matrix <- set_intermodule_objects("mapping_matrix")
     # Store global filter states ----
-    filter <- isolate(slices_global())
-    snapshot_history <- reactiveVal({
-      list(
-        "Initial application state" = as.list(filter, recursive = TRUE)
-      )
-    })
+    snapshot_history <- set_intermodule_objects("snapshot_history")
 
     # Snapshot current application state ----
     # Name snaphsot.

--- a/R/module_snapshot_manager.R
+++ b/R/module_snapshot_manager.R
@@ -320,7 +320,6 @@ snapshot_manager_srv <- function(id) {
       }
     })
 
-    return(snapshot_history)
   })
 }
 

--- a/R/module_snapshot_manager.R
+++ b/R/module_snapshot_manager.R
@@ -108,7 +108,7 @@ snapshot_manager_srv <- function(id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
-    # Retrieve intermodule objects ----
+    # Retrieve global objects ----
     slices_global <- GS$set_global("slices_global")
     filtered_data_list <- GS$set_global("filtered_data_list")
     mapping_matrix <- GS$set_global("mapping_matrix")

--- a/R/module_state_manager.R
+++ b/R/module_state_manager.R
@@ -41,13 +41,24 @@ state_manager_srv <- function(id) {
     sesh <- get_master_session()
 
     # Retrieve intermodule objects ----
-    slices_global <- set_intermodule_objects("slices_global")
-    filtered_data_list <- set_intermodule_objects("filtered_data_list")
-    mapping_matrix <- set_intermodule_objects("mapping_matrix")
-    snapshot_history <- set_intermodule_objects("snapshot_history")
+    slices_global <- GS$set_global("slices_global")
+    filtered_data_list <- GS$set_global("filtered_data_list")
+    mapping_matrix <- GS$set_global("mapping_matrix")
+    snapshot_history <- GS$set_global("snapshot_history")
 
-    # Store input states ----
-    grab_history <- set_intermodule_objects("grab_history")
+    # Register setter for global grab history ----
+    GS$add_setter("grab_history", setter_grab_history)
+    # Store global filter states ----
+    grab_history <- GS$set_global("grab_history")
+
+    # Retrieve intermodule objects ----
+    # slices_global <- set_intermodule_objects("slices_global")
+    # filtered_data_list <- set_intermodule_objects("filtered_data_list")
+    # mapping_matrix <- set_intermodule_objects("mapping_matrix")
+    # snapshot_history <- set_intermodule_objects("snapshot_history")
+    #
+    # # Store input states ----
+    # grab_history <- set_intermodule_objects("grab_history")
 
     sesh$onBookmark(function(state) {
       # Add current filter state to bookmark.
@@ -164,5 +175,21 @@ get_master_session <- function() {
     local_session
   } else {
     app_session
+  }
+}
+
+
+
+# setter for global variable ----
+#' @keywords internal
+#' @noRd
+setter_grab_history <- function() {
+  sesh <- getDefaultReactiveDomain()
+  if (is.null(sesh$userData$grab_history)) {
+    sesh$userData$grab_history <- reactiveVal({
+      list()
+    })
+  } else {
+    sesh$userData$grab_history
   }
 }

--- a/R/module_state_manager.R
+++ b/R/module_state_manager.R
@@ -40,7 +40,7 @@ state_manager_srv <- function(id) {
     ns <- session$ns
     sesh <- get_master_session()
 
-    # Retrieve intermodule objects ----
+    # Retrieve global objects ----
     slices_global <- GS$set_global("slices_global")
     filtered_data_list <- GS$set_global("filtered_data_list")
     mapping_matrix <- GS$set_global("mapping_matrix")
@@ -48,17 +48,9 @@ state_manager_srv <- function(id) {
 
     # Register setter for global grab history ----
     GS$add_setter("grab_history", setter_grab_history)
+
     # Store global filter states ----
     grab_history <- GS$set_global("grab_history")
-
-    # Retrieve intermodule objects ----
-    # slices_global <- set_intermodule_objects("slices_global")
-    # filtered_data_list <- set_intermodule_objects("filtered_data_list")
-    # mapping_matrix <- set_intermodule_objects("mapping_matrix")
-    # snapshot_history <- set_intermodule_objects("snapshot_history")
-    #
-    # # Store input states ----
-    # grab_history <- set_intermodule_objects("grab_history")
 
     sesh$onBookmark(function(state) {
       # Add current filter state to bookmark.

--- a/R/module_state_manager.R
+++ b/R/module_state_manager.R
@@ -33,24 +33,21 @@ state_manager_ui <- function(id) {
 #' @rdname state_manager_module
 #' @keywords internal
 #'
-state_manager_srv <- function(id, slices_global, mapping_matrix, filtered_data_list, snapshot_history) {
+state_manager_srv <- function(id) {
   checkmate::assert_character(id)
-  checkmate::assert_true(is.reactive(slices_global))
-  checkmate::assert_class(isolate(slices_global()), "teal_slices")
-  checkmate::assert_true(is.reactive(mapping_matrix))
-  checkmate::assert_data_frame(isolate(mapping_matrix()), null.ok = TRUE)
-  checkmate::assert_list(filtered_data_list, types = "FilteredData", any.missing = FALSE, names = "named")
-  checkmate::assert_true(is.reactive(snapshot_history))
-  checkmate::assert_list(isolate(snapshot_history()), names = "unique")
 
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     sesh <- get_master_session()
 
-    # Store input states.
-    grab_history <- reactiveVal({
-      list()
-    })
+    # Retrieve intermodule objects ----
+    slices_global <- set_intermodule_objects("slices_global")
+    filtered_data_list <- set_intermodule_objects("filtered_data_list")
+    mapping_matrix <- set_intermodule_objects("mapping_matrix")
+    snapshot_history <- set_intermodule_objects("snapshot_history")
+
+    # Store input states ----
+    grab_history <- set_intermodule_objects("grab_history")
 
     sesh$onBookmark(function(state) {
       # Add current filter state to bookmark.


### PR DESCRIPTION
Extension of #1011 

Five key objects are copied to the app session's `userData`: `slices_global`, `filtered_data_list`, `mapping_matrix`, `snapshot_history`, and `state_history`.
These objects can now be used and modified from any module.

There are multiple implementation within this one draft. Use the SHAs to checkout the one you want to see.

<details>
<summary> first implementation (f987c04d9d555db13cf43ef6730af8308d8cc121)</summary>

Introduced a function `set_intermodule_objects` that sets these objects in the scope of a module:
- checks if an object exists in session
- if YES, assigns a copy in module environment (by reference)
- if NO, creates the object
This function is dirty as all hell, it depends on state and has side effects. Possibly is buggy.

`set_intermodule_objects` is called in filter manager, snapshot manager, and state manager so that the key objects can be created and used. Passing them as arguments is no longer necessary.
Note this is discouraged by `shiny` but perhaps it will allow us to do some things otherwise impossible.

</details>

The problem with the first implementation is that `set_intermodule_objects` contains all routines for setting the key objects and thus the default value of the key objects is separated from the module that uses it. It would be better if they (the routine and the module) can be kept in one file. Therefore, a need arises for a way to send such routines to a place where they can be accessed by all modules.

<details>
<summary> second implementation (3f79bb201667b4f88f15f1faa88178e8ac1d373d)</summary>

Introduced a dedicated setter function for every key object (five in total). These setter functions work much like `set_intermodule_objects` in the first implementation. They are defined in the same file as the modules in which the key object is created, along with all necessary utility functions for better maintainability.

Introduced R6 class `GlobalSetter` as a hub for the setter functions.
The `GlobalSetter` class has two methods:
- `$add_setter`: register function that sets global object
- `$set_global`: call setter function to set global object
A singleton `GlobalSetter`, `GS` is created in the package namespace (assignment is made in `zzz.R`). From there it be accessed by all modules.
Every module can register a setter function for the key objects that it creates in `GS`. Every module can use `GS` to call a setter function.

</details>

#### ISSUES

- `update*Input` is still a problem.
- application opened from bookmark still lacks the most recent bookmark (itself)