### PR TITLE
Fix warning when running init

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -291,7 +291,7 @@ create_app_id <- function(data, modules) {
   checkmate::assert_multi_class(data, c("teal_data", "teal_data_module"))
   checkmate::assert_class(modules, "teal_modules")
 
-  hashables <- c(data, modules)
+  hashables <- c(data = data, modules)
   hashables$data <- if (inherits(hashables$data, "teal_data")) {
     as.list(hashables$data@env)
   } else if (inherits(data, "teal_data_module")) {


### PR DESCRIPTION
Fixes #1058

Warning no longer appear.

``` r
library(teal)
#> Loading required package: shiny
#> Loading required package: teal.data
#> Loading required package: teal.code
#> Loading required package: teal.slice
#> Registered S3 method overwritten by 'teal':
#>   method        from      
#>   c.teal_slices teal.slice
#> 
#> You are using teal version 0.14.0.9039
#> 
#> Attaching package: 'teal'
#> The following objects are masked from 'package:teal.slice':
#> 
#>     as.teal_slices, teal_slices

app <- init(
  data = teal_data(IRIS = iris, MTCARS = mtcars),
  modules = example_module()
)
```

<sup>Created on 2024-01-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
