### PR TITLE
add css to blur out background when using landing popup module

### DIFF
--- a/inst/css/custom.css
+++ b/inst/css/custom.css
@@ -68,3 +68,7 @@ footer {
 #teal_secondary_col .well {
   margin: 0  0 15px 0;
 }
+
+#shiny-modal:has(> .modal-dialog > .modal-content > #landingpopup) {
+  backdrop-filter: blur(10px);
+}


### PR DESCRIPTION
Fixes #1063

Background is blur before user agree to the disclaimer:
![image](https://github.com/insightsengineering/teal/assets/8597300/02fcf58d-2e35-4c59-bab5-0f37c3f2179b)
