### PR TITLE
updated  arg `id` description and `ui_teal_with_splash` description.

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -34,11 +34,11 @@
 #'   The header of the app.
 #' @param footer (`shiny.tag` or `character(1)`)
 #'   The footer of the app.
-#' @param id (`character`)
-#'   module id to embed it, if provided,
-#'   the server function must be called with [shiny::moduleServer()];
-#'   See the vignette for an example. However, [ui_teal_with_splash()]
-#'   is then preferred to this function.
+#' @param id optional (`character`)
+#'   specifying the module id to be used when embedding the teal app within another `shiny` app as a module.
+#'   - If an id is provided, the server function must be called using [shiny::moduleServer()] with the specified id.
+#'   However, for better integration use [ui_teal_with_splash()] and [srv_teal_with_splash()].
+#'   - If no id is given (i.e., `id = character(0)`), the teal app runs as a standalone application without submodule integration.
 #'
 #' @return named list with server and UI function
 #'
@@ -227,9 +227,8 @@ init <- function(data,
   }
 
   # Note regarding case `id = character(0)`:
-  # rather than using `callModule` and creating a submodule of this module, we directly modify
+  # rather than using `shiny::moduleServer` and creating a submodule of this module, we directly modify
   # the UI and server with `id = character(0)` and calling the server function directly
-  # rather than through `callModule`
   res <- list(
     ui = ui_teal_with_splash(id = id, data = data, title = title, header = header, footer = footer),
     server = function(input, output, session) {

--- a/R/module_teal_with_splash.R
+++ b/R/module_teal_with_splash.R
@@ -1,16 +1,17 @@
 # This file adds a splash screen for delayed data loading on top of teal
 
-#' UI to show a splash screen in the beginning, then delegate to [srv_teal()]
+#' UI to show a splash screen in the beginning, then delegate to [ui_teal()]
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' The splash screen could be used to query for a password to fetch the data.
-#' [init()] is a very thin wrapper around this module useful for end-users which
+#' UI function offers the dynamic display that switches between a custom splash screen
+#' for delayed data loading and a default splash screen.This helps ensure smooth
+#' user interaction, particularly during the initial heavy data processing or
+#' when querying for a password to fetch data.
+#'
+#' [init()] is a very wrapper around this module useful for end-users which
 #' assumes that it is a top-level module and cannot be embedded.
 #' This function instead adheres to the `shiny` module conventions.
-#'
-#' If data is obtained through delayed loading, its splash screen is used. Otherwise,
-#' a default splash screen is shown.
 #'
 #' Please also refer to the doc of [init()].
 #'

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -40,11 +40,13 @@ The header of the app.}
 \item{footer}{(\code{shiny.tag} or \code{character(1)})
 The footer of the app.}
 
-\item{id}{(\code{character})
-module id to embed it, if provided,
-the server function must be called with \code{\link[shiny:moduleServer]{shiny::moduleServer()}};
-See the vignette for an example. However, \code{\link[=ui_teal_with_splash]{ui_teal_with_splash()}}
-is then preferred to this function.}
+\item{id}{optional (\code{character})
+specifying the module id to be used when embedding the teal app within another \code{shiny} app as a module.
+\itemize{
+\item If an id is provided, the server function must be called using \code{\link[shiny:moduleServer]{shiny::moduleServer()}} with the specified id.
+However, for better integration use \code{\link[=ui_teal_with_splash]{ui_teal_with_splash()}} and \code{\link[=srv_teal_with_splash]{srv_teal_with_splash()}}.
+\item If no id is given (i.e., \code{id = character(0)}), the teal app runs as a standalone application without submodule integration.
+}}
 }
 \value{
 named list with server and UI function

--- a/man/srv_teal_with_splash.Rd
+++ b/man/srv_teal_with_splash.Rd
@@ -8,11 +8,13 @@ to \code{\link[=srv_teal]{srv_teal()}}.}
 srv_teal_with_splash(id, data, modules, filter = teal_slices())
 }
 \arguments{
-\item{id}{(\code{character})
-module id to embed it, if provided,
-the server function must be called with \code{\link[shiny:moduleServer]{shiny::moduleServer()}};
-See the vignette for an example. However, \code{\link[=ui_teal_with_splash]{ui_teal_with_splash()}}
-is then preferred to this function.}
+\item{id}{optional (\code{character})
+specifying the module id to be used when embedding the teal app within another \code{shiny} app as a module.
+\itemize{
+\item If an id is provided, the server function must be called using \code{\link[shiny:moduleServer]{shiny::moduleServer()}} with the specified id.
+However, for better integration use \code{\link[=ui_teal_with_splash]{ui_teal_with_splash()}} and \code{\link[=srv_teal_with_splash]{srv_teal_with_splash()}}.
+\item If no id is given (i.e., \code{id = character(0)}), the teal app runs as a standalone application without submodule integration.
+}}
 
 \item{data}{(\code{teal_data} or \code{teal_data_module})
 \code{teal_data} object as returned by \code{\link[teal.data:teal_data]{teal.data::teal_data()}} or \code{teal_data_module}.}

--- a/man/ui_teal_with_splash.Rd
+++ b/man/ui_teal_with_splash.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/module_teal_with_splash.R
 \name{ui_teal_with_splash}
 \alias{ui_teal_with_splash}
-\title{UI to show a splash screen in the beginning, then delegate to \code{\link[=srv_teal]{srv_teal()}}}
+\title{UI to show a splash screen in the beginning, then delegate to \code{\link[=ui_teal]{ui_teal()}}}
 \usage{
 ui_teal_with_splash(
   id,
@@ -33,13 +33,14 @@ The footer of the app.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-The splash screen could be used to query for a password to fetch the data.
-\code{\link[=init]{init()}} is a very thin wrapper around this module useful for end-users which
+UI function offers the dynamic display that switches between a custom splash screen
+for delayed data loading and a default splash screen.This helps ensure smooth
+user interaction, particularly during the initial heavy data processing or
+when querying for a password to fetch data.
+
+\code{\link[=init]{init()}} is a very wrapper around this module useful for end-users which
 assumes that it is a top-level module and cannot be embedded.
 This function instead adheres to the \code{shiny} module conventions.
-
-If data is obtained through delayed loading, its splash screen is used. Otherwise,
-a default splash screen is shown.
 
 Please also refer to the doc of \code{\link[=init]{init()}}.
 }


### PR DESCRIPTION
fixes https://github.com/insightsengineering/teal/issues/1019

I have revised the description of the id parameter to reflect its current usage, based on how it was previously utilized. Additionally, I have rephrased the description of ui_teal_with_splash for better clarity and understanding.

