### PR TITLE
1078 padding added

### DIFF
--- a/inst/css/custom.css
+++ b/inst/css/custom.css
@@ -72,3 +72,8 @@ footer {
 #shiny-modal:has(> .modal-dialog > .modal-content > #landingpopup) {
   backdrop-filter: blur(10px);
 }
+
+body:not(.modal-open) {
+  padding-right: 0 !important;
+  overflow: auto !important;
+}


### PR DESCRIPTION
Closes #1078 

Modified CSS to restore right padding in `body` when modal is not open.
Solution found [here](https://stackoverflow.com/questions/32862394/bootstrap-modals-keep-adding-padding-right-to-body-after-closed).