### PR TITLE
audit linter exceptions

### DIFF
--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -89,9 +89,9 @@ ui_teal <- function(id,
   )
 
   # show busy icon when `shiny` session is busy computing stuff
-  # based on https://stackoverflow.com/questions/17325521/r-shiny-display-loading-message-while-function-is-running/22475216#22475216 # nolint
+  # based on https://stackoverflow.com/questions/17325521/r-shiny-display-loading-message-while-function-is-running/22475216#22475216 # nolint: line_length.
   shiny_busy_message_panel <- conditionalPanel(
-    condition = "(($('html').hasClass('shiny-busy')) && (document.getElementById('shiny-notification-panel') == null))", # nolint
+    condition = "(($('html').hasClass('shiny-busy')) && (document.getElementById('shiny-notification-panel') == null))", # nolint: line_length.
     div(
       icon("arrows-rotate", "spin fa-spin"),
       "Computing ...",

--- a/R/modules.R
+++ b/R/modules.R
@@ -124,7 +124,7 @@
 #'
 module <- function(label = "module",
                    server = function(id, ...) {
-                     moduleServer(id, function(input, output, session) {}) # nolint
+                     moduleServer(id, function(input, output, session) {})
                    },
                    ui = function(id, ...) {
                      tags$p(paste0("This module has no UI (id: ", id, " )"))
@@ -281,7 +281,7 @@ modules <- function(..., label = "root") {
 
 #' @rdname teal_modules
 #' @export
-format.teal_module <- function(x, indent = 0, ...) { # nolint
+format.teal_module <- function(x, indent = 0, ...) {
   paste0(paste(rep(" ", indent), collapse = ""), "+ ", x$label, "\n", collapse = "")
 }
 
@@ -296,7 +296,7 @@ print.teal_module <- function(x, ...) {
 
 #' @rdname teal_modules
 #' @export
-format.teal_modules <- function(x, indent = 0, ...) { # nolint
+format.teal_modules <- function(x, indent = 0, ...) {
   paste(
     c(
       paste0(rep(" ", indent), "+ ", x$label, "\n"),

--- a/R/tdata.R
+++ b/R/tdata.R
@@ -101,7 +101,7 @@ new_tdata <- function(data, code = "", join_keys = NULL, metadata = NULL) {
 #' my_env <- isolate(tdata2env(data))
 #'
 #' @export
-tdata2env <- function(data) { # nolint
+tdata2env <- function(data) {
   checkmate::assert_class(data, "tdata")
   list2env(lapply(data, function(x) if (is.reactive(x)) x() else x))
 }

--- a/R/teal_reporter.R
+++ b/R/teal_reporter.R
@@ -6,7 +6,7 @@
 #' meta data.
 #' @export
 #'
-TealReportCard <- R6::R6Class( # nolint: object_name_linter.
+TealReportCard <- R6::R6Class( # nolint: object_name.
   classname = "TealReportCard",
   inherit = teal.reporter::ReportCard,
   public = list(

--- a/R/teal_slices.R
+++ b/R/teal_slices.R
@@ -119,7 +119,7 @@ teal_slices <- function(...,
 #' @export
 #' @keywords internal
 #'
-as.teal_slices <- function(x) { # nolint
+as.teal_slices <- function(x) { # nolint: object_name.
   checkmate::assert_list(x)
   lapply(x, checkmate::assert_list, names = "named", .var.name = "list element")
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,4 @@
-.onLoad <- function(libname, pkgname) { # nolint
+.onLoad <- function(libname, pkgname) {
   # adapted from https://github.com/r-lib/devtools/blob/master/R/zzz.R
   teal_default_options <- list(teal.show_js_log = FALSE)
 
@@ -14,7 +14,7 @@
   invisible()
 }
 
-.onAttach <- function(libname, pkgname) { # nolint
+.onAttach <- function(libname, pkgname) {
   packageStartupMessage(
     "\nYou are using teal version ",
     # `system.file` uses the `shim` of `system.file` by `teal`
@@ -28,7 +28,7 @@ setdiff_teal_slices <- getFromNamespace("setdiff_teal_slices", "teal.slice")
 # This one is here because it is needed by c.teal_slices but we don't want it exported from teal.slice.
 coalesce_r <- getFromNamespace("coalesce_r", "teal.slice")
 # all *Block objects are private in teal.reporter
-RcodeBlock <- getFromNamespace("RcodeBlock", "teal.reporter") # nolint
+RcodeBlock <- getFromNamespace("RcodeBlock", "teal.reporter") # nolint: object_name.
 
 # Use non-exported function(s) from teal.code
 # This one is here because lang2calls should not be exported from teal.code

--- a/tests/testthat/test-module_teal_with_splash.R
+++ b/tests/testthat/test-module_teal_with_splash.R
@@ -186,7 +186,7 @@ testthat::test_that("srv_teal_with_splash gets observe event from srv_teal", {
 
 testthat::test_that("srv_teal_with_splash accepts data after within.teal_data_module", {
   tdm <- teal_data_module(ui = function(id) div(), server = function(id) reactive(teal_data(IRIS = iris)))
-  tdm2 <- within(tdm, IRIS$id <- seq_len(NROW(IRIS$Species))) # nolint: object_name_linter.
+  tdm2 <- within(tdm, IRIS$id <- seq_len(NROW(IRIS$Species))) # nolint: object_name.
 
   testthat::expect_no_error(
     shiny::testServer(

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -377,7 +377,7 @@ testthat::test_that("modules_depth increases depth by 1 for each teal_modules", 
 # is_arg_used -----
 get_srv_and_ui <- function() {
   list(
-    server_fun = function(id, datasets) {}, # nolint
+    server_fun = function(id, datasets) {},
     ui_fun = function(id, ...) {
       tags$p(paste0("id: ", id))
     }

--- a/tests/testthat/test-teal_data_module-eval_code.R
+++ b/tests/testthat/test-teal_data_module-eval_code.R
@@ -8,7 +8,7 @@ testthat::test_that("within.teal_data_module returns an object with teal_data_mo
     }
   )
 
-  tdm2 <- within(tdm, IRIS$id <- seq_len(nrow(IRIS))) # nolint: object_name_linter.
+  tdm2 <- within(tdm, IRIS$id <- seq_len(nrow(IRIS))) # nolint: object_name.
 
   testthat::expect_s3_class(tdm2, "teal_data_module")
 })
@@ -41,7 +41,7 @@ testthat::test_that("within.teal_data_module modifies the reactive tea_data obje
     }
   )
 
-  tdm2 <- within(tdm, IRIS$id <- seq_len(nrow(IRIS))) # nolint: object_name_linter.
+  tdm2 <- within(tdm, IRIS$id <- seq_len(nrow(IRIS))) # nolint: object_name.
 
   testthat::expect_no_error(
     shiny::testServer(

--- a/vignettes/bootstrap-themes-in-teal.Rmd
+++ b/vignettes/bootstrap-themes-in-teal.Rmd
@@ -97,7 +97,7 @@ options("teal.bs_theme" = bslib::bs_theme(version = "5"))
 library(teal)
 
 app <- init(
-  data = teal_data(IRIS = iris), # nolint
+  data = teal_data(IRIS = iris), # nolint: line_length.
   filter = teal_slices(teal_slice("IRIS", "Sepal.Length", selected = c(5, 7))),
   modules = modules(example_module(), example_module()),
   header = "My first teal application"


### PR DESCRIPTION
Removed superfluous `# nolint` statements.
Added linter specification to remaining exceptions.