### PR TITLE
Fix

### DIFF
--- a/R/module_state_manager.R
+++ b/R/module_state_manager.R
@@ -53,15 +53,21 @@ state_manager_srv <- function(id, slices_global, mapping_matrix, filtered_data_l
     })
 
     sesh$onBookmark(function(state) {
+      logger::log_trace("state_manager_srv@onBookmark initialized")
       # Add current filter state to bookmark.
       snapshot <- as.list(slices_global(), recursive = TRUE)
       attr(snapshot, "mapping") <- matrix_to_mapping(mapping_matrix())
       state$values$filter_state_on_bookmark <- snapshot
       # Add snapshot history and grab history to bookmark.
-      state$values$snapshot_history <- snapshot_history()   # isolate this?
-      state$values$grab_history <- grab_history()           # isolate this?
+      state$values$snapshot_history <- snapshot_history() # isolate this?
+      state$values$grab_history <- grab_history() # isolate this?
+    })
+    sesh$onRestore(function(state) {
+      logger::log_trace("state_manager_srv@onRestore initialized")
+      sesh$userData$is_restored <- TRUE
     })
     sesh$onRestored(function(state) {
+      logger::log_trace("state_manager_srv@onRestored initialized")
       # Restore filter state.
       snapshot <- state$values$filter_state_on_bookmark
       snapshot_state <- as.teal_slices(snapshot)
@@ -82,6 +88,7 @@ state_manager_srv <- function(id, slices_global, mapping_matrix, filtered_data_l
     })
 
     sesh$onBookmarked(function(url) {
+      logger::log_trace("state_manager_srv@onBookmarked initialized")
       grab_name <- trimws(input$grab_name)
       if (identical(grab_name, "")) {
         showNotification(


### PR DESCRIPTION
I've investigated the problem of not-restoring module inputs and `updateInput` is not a biggest problem there. Fundamental problem is that `onRestored` is triggered before teal_module(s) is called. It means that `onRestore` has (yet) no values to update. 
Root of the problem lays [here](https://github.com/insightsengineering/teal/blob/f606cb9e0fef9aab767a3f09b7f36f10d2a9e2c9/R/module_nested_tabs.R#L220). 
This commit seems to solve this issue:

<details>
<summary> example app </summary>

```r
options(teal.log_level = "TRACE", teal.show_js_log = TRUE, teal.bs_theme = bslib::bs_theme(version = 3))
logger::log_warnings()
pkgload::load_all("teal")

tdata <- teal_data() |>
  within({
    set.seed(1)
    library(scda)
    library(MultiAssayExperiment)
    library(stats)
    ts_example <- ts(matrix(rnorm(300), 100, 3), start = c(1961, 1), frequency = 12)
    data(miniACC, envir = environment())
    a_matrix <- matrix(rnorm(100), ncol = 5, dimnames = list(rownames = NULL, colnames = c("a", "b", "c", "d", "e")))
    a_vector <- "elo"
    ADSL <- synthetic_cdisc_data("latest")$adsl
    attr(ADSL, "label") <- "ADSL dataset"
    ADSL$categorical <- sample(letters[1:3], size = nrow(ADSL), replace = TRUE, prob = c(.1, .3, .6))
    ADTTE <- synthetic_cdisc_data("latest")$adtte
    ADRS <- synthetic_cdisc_data("latest")$adrs
  })

datanames(tdata) <- c("ADSL", "ADTTE", "ADRS", "miniACC", "a_vector", "a_matrix", "ts_example")
join_keys(tdata) <- default_cdisc_join_keys[c("ADSL", "ADTTE", "ADRS")]

data <- teal_data_module(
  ui = function(id) {
    ns <- NS(id)
    div(actionButton(ns("btn"), "Click me"))
  },
  server = function(id) {
    moduleServer(id, function(input, output, session) {
      eventReactive(input$btn, tdata)
    })
  }
)

app <- init(
  data = tdata,
  modules = modules(
    modules(
      label = "tab1",
      example_module("funny"),
      example_module("funny", datanames = "miniACC"),
      example_module("funny2", datanames = c("ADTTE", "ADTTE")), # will limit datanames to ADTTE and ADSL (parent),
      teal.modules.general::tm_data_table()
    )
  )
)

runApp(app)

```

</details>