### PR TITLE
Enables module-specific filters on `init` example

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -78,12 +78,12 @@
 #'     teal_slice(dataname = "new_iris", varname = "Sepal.Length"),
 #'     teal_slice(dataname = "new_mtcars", varname = "cyl"),
 #'     exclude_varnames = list(new_iris = c("Sepal.Width", "Petal.Width")),
+#'     module_specific = TRUE,
 #'     mapping = list(
 #'       `example teal module` = "new_iris Species",
 #'       `Iris Sepal.Length histogram` = "new_iris Species",
 #'       global_filters = "new_mtcars cyl"
-#'     ),
-#'     module_specific = TRUE
+#'     )
 #'   ),
 #'   title = "App title",
 #'   header = tags$h1("Sample App"),

--- a/R/init.R
+++ b/R/init.R
@@ -82,7 +82,8 @@
 #'       `example teal module` = "new_iris Species",
 #'       `Iris Sepal.Length histogram` = "new_iris Species",
 #'       global_filters = "new_mtcars cyl"
-#'     )
+#'     ),
+#'     module_specific = TRUE
 #'   ),
 #'   title = "App title",
 #'   header = tags$h1("Sample App"),

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -96,7 +96,8 @@ app <- init(
       `example teal module` = "new_iris Species",
       `Iris Sepal.Length histogram` = "new_iris Species",
       global_filters = "new_mtcars cyl"
-    )
+    ),
+    module_specific = TRUE
   ),
   title = "App title",
   header = tags$h1("Sample App"),

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -92,12 +92,12 @@ app <- init(
     teal_slice(dataname = "new_iris", varname = "Sepal.Length"),
     teal_slice(dataname = "new_mtcars", varname = "cyl"),
     exclude_varnames = list(new_iris = c("Sepal.Width", "Petal.Width")),
+    module_specific = TRUE,
     mapping = list(
       `example teal module` = "new_iris Species",
       `Iris Sepal.Length histogram` = "new_iris Species",
       global_filters = "new_mtcars cyl"
-    ),
-    module_specific = TRUE
+    )
   ),
   title = "App title",
   header = tags$h1("Sample App"),


### PR DESCRIPTION
# Pull Request

Fixes #1132


#### Changes description

* Enables module specific filters in `init` example
  * note: vignettes already use it when there's a mapping