### PR TITLE
503 `$get_html_rvest` method for `TealAppDriver`

### DIFF
--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -359,6 +359,25 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #' @return Nothing. Opens the underlying teal app in the browser.
     open_url = function() {
       browseURL(self$get_url())
+    },
+    #' @return The `TealAppDriver` object invisibly.
+    open_filter_manager = function() {
+      active_ns <- self$filter_manager_ns()
+      ns <- self$helper_NS(active_ns)
+
+      self$click(ns("show"))
+      self$wait_for_idle(500)
+      invisible(self)
+    },
+    #' @description
+    #' Wrapper around `get_html` that passes the output directly to `rvest::read_html`.
+    #'
+    #' @param selector `(character(1))` passed to `get_html`.
+    #'
+    #' @return An XML document.
+    read_html = function(selector) {
+      self$get_html(selector) %>%
+        rvest::read_html()
     }
   ),
   # private members ----

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -360,8 +360,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #'
     #' @return An XML document.
     get_html_rvest = function(selector) {
-      self$get_html(selector) %>%
-        rvest::read_html()
+      rvest::read_html(self$get_html(selector))
     },
     #' Wrapper around `get_url()` method that opens the app in the browser.
     #'

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -354,6 +354,15 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       invisible(self)
     },
     #' @description
+    #' Wrapper around `get_html` that passes the output directly to `rvest::read_html`.
+    #'
+    #' @param selector `(character(1))` passed to `get_html`.
+    #'
+    #' @return An XML document.
+    get_html_rvest = function(selector) {
+      self$get_html(selector) %>%
+        rvest::read_html()
+    },
     #' Wrapper around `get_url()` method that opens the app in the browser.
     #'
     #' @return Nothing. Opens the underlying teal app in the browser.

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -368,16 +368,6 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #' @return Nothing. Opens the underlying teal app in the browser.
     open_url = function() {
       browseURL(self$get_url())
-    },
-    #' @description
-    #' Wrapper around `get_html` that passes the output directly to `rvest::read_html`.
-    #'
-    #' @param selector `(character(1))` passed to `get_html`.
-    #'
-    #' @return An XML document.
-    read_html = function(selector) {
-      self$get_html(selector) %>%
-        rvest::read_html()
     }
   ),
   # private members ----

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -369,15 +369,6 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     open_url = function() {
       browseURL(self$get_url())
     },
-    #' @return The `TealAppDriver` object invisibly.
-    open_filter_manager = function() {
-      active_ns <- self$filter_manager_ns()
-      ns <- self$helper_NS(active_ns)
-
-      self$click(ns("show"))
-      self$wait_for_idle(500)
-      invisible(self)
-    },
     #' @description
     #' Wrapper around `get_html` that passes the output directly to `rvest::read_html`.
     #'

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -38,6 +38,7 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-add_filter_var}{\code{TealAppDriver$add_filter_var()}}
 \item \href{#method-TealAppDriver-remove_filter_var}{\code{TealAppDriver$remove_filter_var()}}
 \item \href{#method-TealAppDriver-set_active_filter_selection}{\code{TealAppDriver$set_active_filter_selection()}}
+\item \href{#method-TealAppDriver-get_html_rvest}{\code{TealAppDriver$get_html_rvest()}}
 \item \href{#method-TealAppDriver-open_url}{\code{TealAppDriver$open_url()}}
 \item \href{#method-TealAppDriver-open_filter_manager}{\code{TealAppDriver$open_filter_manager()}}
 \item \href{#method-TealAppDriver-read_html}{\code{TealAppDriver$read_html()}}
@@ -451,10 +452,30 @@ The \code{TealAppDriver} object invisibly.
 }
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TealAppDriver-get_html_rvest"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-get_html_rvest}{}}}
+\subsection{Method \code{get_html_rvest()}}{
+Wrapper around \code{get_html} that passes the output directly to \code{rvest::read_html}.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_html_rvest(selector)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{selector}}{\code{(character(1))} passed to \code{get_html}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+An XML document.
+Wrapper around \code{get_url()} method that opens the app in the browser.
+}
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TealAppDriver-open_url"></a>}}
 \if{latex}{\out{\hypertarget{method-TealAppDriver-open_url}{}}}
 \subsection{Method \code{open_url()}}{
-Wrapper around \code{get_url()} method that opens the app in the browser.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$open_url()}\if{html}{\out{</div>}}
 }

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -40,7 +40,6 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-set_active_filter_selection}{\code{TealAppDriver$set_active_filter_selection()}}
 \item \href{#method-TealAppDriver-get_html_rvest}{\code{TealAppDriver$get_html_rvest()}}
 \item \href{#method-TealAppDriver-open_url}{\code{TealAppDriver$open_url()}}
-\item \href{#method-TealAppDriver-open_filter_manager}{\code{TealAppDriver$open_filter_manager()}}
 \item \href{#method-TealAppDriver-read_html}{\code{TealAppDriver$read_html()}}
 \item \href{#method-TealAppDriver-clone}{\code{TealAppDriver$clone()}}
 }
@@ -482,18 +481,6 @@ Wrapper around \code{get_url()} method that opens the app in the browser.
 
 \subsection{Returns}{
 Nothing. Opens the underlying teal app in the browser.
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TealAppDriver-open_filter_manager"></a>}}
-\if{latex}{\out{\hypertarget{method-TealAppDriver-open_filter_manager}{}}}
-\subsection{Method \code{open_filter_manager()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$open_filter_manager()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-The \code{TealAppDriver} object invisibly.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -40,7 +40,6 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-set_active_filter_selection}{\code{TealAppDriver$set_active_filter_selection()}}
 \item \href{#method-TealAppDriver-get_html_rvest}{\code{TealAppDriver$get_html_rvest()}}
 \item \href{#method-TealAppDriver-open_url}{\code{TealAppDriver$open_url()}}
-\item \href{#method-TealAppDriver-read_html}{\code{TealAppDriver$read_html()}}
 \item \href{#method-TealAppDriver-clone}{\code{TealAppDriver$clone()}}
 }
 }
@@ -481,26 +480,6 @@ Wrapper around \code{get_url()} method that opens the app in the browser.
 
 \subsection{Returns}{
 Nothing. Opens the underlying teal app in the browser.
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TealAppDriver-read_html"></a>}}
-\if{latex}{\out{\hypertarget{method-TealAppDriver-read_html}{}}}
-\subsection{Method \code{read_html()}}{
-Wrapper around \code{get_html} that passes the output directly to \code{rvest::read_html}.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$read_html(selector)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{selector}}{\code{(character(1))} passed to \code{get_html}.}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-An XML document.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -39,6 +39,8 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-remove_filter_var}{\code{TealAppDriver$remove_filter_var()}}
 \item \href{#method-TealAppDriver-set_active_filter_selection}{\code{TealAppDriver$set_active_filter_selection()}}
 \item \href{#method-TealAppDriver-open_url}{\code{TealAppDriver$open_url()}}
+\item \href{#method-TealAppDriver-open_filter_manager}{\code{TealAppDriver$open_filter_manager()}}
+\item \href{#method-TealAppDriver-read_html}{\code{TealAppDriver$read_html()}}
 \item \href{#method-TealAppDriver-clone}{\code{TealAppDriver$clone()}}
 }
 }
@@ -459,6 +461,38 @@ Wrapper around \code{get_url()} method that opens the app in the browser.
 
 \subsection{Returns}{
 Nothing. Opens the underlying teal app in the browser.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TealAppDriver-open_filter_manager"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-open_filter_manager}{}}}
+\subsection{Method \code{open_filter_manager()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$open_filter_manager()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+The \code{TealAppDriver} object invisibly.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TealAppDriver-read_html"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-read_html}{}}}
+\subsection{Method \code{read_html()}}{
+Wrapper around \code{get_html} that passes the output directly to \code{rvest::read_html}.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$read_html(selector)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{selector}}{\code{(character(1))} passed to \code{get_html}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+An XML document.
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-shinytest2-init.R
+++ b/tests/testthat/test-shinytest2-init.R
@@ -30,8 +30,7 @@ testthat::test_that("e2e: init creates UI containing specified title, favicon, h
     app_title
   )
   testthat::expect_equal(
-    app$get_html("head > link[rel='icon']") %>%
-      rvest::read_html() %>%
+    app$read_html("head > link[rel='icon']") %>%
       rvest::html_elements("link") %>%
       rvest::html_attr("href"),
     app_favicon

--- a/tests/testthat/test-shinytest2-init.R
+++ b/tests/testthat/test-shinytest2-init.R
@@ -30,7 +30,7 @@ testthat::test_that("e2e: init creates UI containing specified title, favicon, h
     app_title
   )
   testthat::expect_equal(
-    app$read_html("head > link[rel='icon']") %>%
+    app$get_html_rvest("head > link[rel='icon']") %>%
       rvest::html_elements("link") %>%
       rvest::html_attr("href"),
     app_favicon

--- a/tests/testthat/test-shinytest2-modules.R
+++ b/tests/testthat/test-shinytest2-modules.R
@@ -78,8 +78,7 @@ testthat::test_that("e2e: filter panel is not displayed when datanames is NULL",
   app$wait_for_idle(timeout = default_idle_timeout)
 
   testthat::expect_identical(
-    app$get_html(".teal_secondary_col") %>%
-      rvest::read_html() %>%
+    app$read_html(".teal_secondary_col") %>%
       rvest::html_element("div") %>%
       rvest::html_attr("style"),
     "display: none;"

--- a/tests/testthat/test-shinytest2-modules.R
+++ b/tests/testthat/test-shinytest2-modules.R
@@ -78,7 +78,7 @@ testthat::test_that("e2e: filter panel is not displayed when datanames is NULL",
   app$wait_for_idle(timeout = default_idle_timeout)
 
   testthat::expect_identical(
-    app$read_html(".teal_secondary_col") %>%
+    app$get_html_rvest(".teal_secondary_col") %>%
       rvest::html_element("div") %>%
       rvest::html_attr("style"),
     "display: none;"

--- a/tests/testthat/test-shinytest2-reporter.R
+++ b/tests/testthat/test-shinytest2-reporter.R
@@ -4,8 +4,7 @@ testthat::test_that("e2e: reporter tab is created when a module has reporter", {
     modules = report_module(label = "Module with Reporter")
   )
 
-  teal_tabs <- app$get_html(selector = "#teal-main_ui-root-active_tab") %>%
-    rvest::read_html() %>%
+  teal_tabs <- app$get_html_rvest(selector = "#teal-main_ui-root-active_tab") %>%
     rvest::html_elements("a")
   tab_names <- setNames(
     rvest::html_attr(teal_tabs, "data-value"),
@@ -24,8 +23,7 @@ testthat::test_that("e2e: reporter tab is not created when a module has no repor
     data = simple_teal_data(),
     modules = example_module(label = "Example Module")
   )
-  teal_tabs <- app$get_html(selector = "#teal-main_ui-root-active_tab") %>%
-    rvest::read_html() %>%
+  teal_tabs <- app$get_html_rvest(selector = "#teal-main_ui-root-active_tab") %>%
     rvest::html_elements("a")
   tab_names <- setNames(
     rvest::html_attr(teal_tabs, "data-value"),

--- a/tests/testthat/test-shinytest2-utils.R
+++ b/tests/testthat/test-shinytest2-utils.R
@@ -5,8 +5,7 @@ testthat::test_that("e2e: show/hide hamburger works as expected", {
   )
 
   get_class_attributes <- function(app, selector) {
-    element <- app$get_html(selector = selector) %>%
-      rvest::read_html() %>%
+    element <- app$read_html(selector = selector) %>%
       rvest::html_elements(selector)
     list(
       class = rvest::html_attr(element, "class"),

--- a/tests/testthat/test-shinytest2-utils.R
+++ b/tests/testthat/test-shinytest2-utils.R
@@ -5,7 +5,7 @@ testthat::test_that("e2e: show/hide hamburger works as expected", {
   )
 
   get_class_attributes <- function(app, selector) {
-    element <- app$read_html(selector = selector) %>%
+    element <- app$get_html_rvest(selector = selector) %>%
       rvest::html_elements(selector)
     list(
       class = rvest::html_attr(element, "class"),


### PR DESCRIPTION
So instead of `app$get_html(selector) %>% rvest::read_html()` we can shortly write `app$read_html(selector)`.