### PR TITLE
vbump teal.data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ BugReports: https://github.com/insightsengineering/teal/issues
 Depends:
     R (>= 4.0),
     shiny (>= 1.7.0),
-    teal.data (>= 0.4.0),
+    teal.data (>= 0.5.0),
     teal.slice (>= 0.5.0)
 Imports:
     checkmate (>= 2.1.0),


### PR DESCRIPTION
fix verdepcheck pipelines - last built: https://github.com/insightsengineering/teal/actions/runs/8585966547

`min_isolated` fails with this:
```
  ── Error ('test-module_nested_tabs.R:4'): (code run outside of `test_that()`) ──
  Error in `.local(object, deparse, ...)`: unused argument (check_names = FALSE)
  Backtrace:
      ▆
   1. └─teal:::teal_data_to_filtered_data(teal_data) at test-module_nested_tabs.R:4:1
   2.   ├─teal.data::get_code(x, datanames = datanames, check_names = FALSE)
   3.   └─teal.data::get_code(x, datanames = datanames, check_names = FALSE)
 ```

`check_names` argument (supported via `...`) is missing in [`0.4.0`](https://github.com/insightsengineering/teal.data/blob/7106fa8f1e16c89b52b769de8db436afe27e92da/R/teal_data-get_code.R#L104) and it's there in [`0.5.0`](https://github.com/insightsengineering/teal.data/blob/520cb12e73ea34b72c12efede19d7de4dd863442/R/teal_data-get_code.R#L107)
