### PR TITLE
Tests wait for idle by default after setting module input

### DIFF
--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -232,6 +232,8 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         value,
         ...
       )
+      dots <- rlang::list2(...)
+      if (!isFALSE(dots[[wait]])) self$wait_for_idle() # Default behavior is to wait
       invisible(self)
     },
     #' @description

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -73,7 +73,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #' @param ... arguments passed to parent [`shinytest2::AppDriver`] `click()` method.
     click = function(...) {
       super$click(...)
-      self$wait_for_idle(5000)
+      self$wait_for_idle()
     },
     #' @description
     #' Check if the app has shiny errors. This checks for global shiny errors.


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Part of https://github.com/insightsengineering/coredev-tasks/issues/503

### Changes description

- [feature] Wait for app to be idle by default (skips if `wait = FALSE` parameter is passed)
- [fix] Removes 5s waiting on every `app_driver$click()`
  - It was waiting for UI to be stable for 5s, instead of setting the timeout.
  - Current default timeout is set on constructor at 20s