### PR TITLE
Fixes integration tests when Chrome >=105 is not installed

### DIFF
--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -65,6 +65,20 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         )
       )
 
+      # Check for minimum version of Chrome that supports the tests
+      #  - Element.checkVisibility was added on 105
+      chrome_version <- numeric_version(
+        gsub(
+          "[[:alnum:]_]+/", # Prefix that ends with forward slash
+          "",
+          self$get_chromote_session()$Browser$getVersion()$product
+        ),
+        strict = FALSE
+      )
+
+      testthat::skip_if_not(!is.na(chrome_version) && chrome_version >= 105)
+      # end od check
+
       private$set_active_ns()
       self$wait_for_idle()
     },

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -76,8 +76,20 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         strict = FALSE
       )
 
-      testthat::skip_if(is.na(chrome_version), "Problem getting Chrome version.")
-      testthat::skip_if(chrome_version < 105, "Chrome version is not supported, please upgrade.")
+      required_version <- 105
+
+      testthat::skip_if(
+        is.na(chrome_version),
+        "Problem getting Chrome version, please contact the developers."
+      )
+      testthat::skip_if(
+        chrome_version < required_version,
+        sprintf(
+          "Chrome version '%s' is not supported, please upgrade to %d or above.",
+          chrome_version,
+          required_version
+        )
+      )
       # end od check
 
       private$set_active_ns()

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -85,7 +85,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       testthat::skip_if(
         chrome_version < required_version,
         sprintf(
-          "Chrome version '%s' is not supported, please upgrade to %d or above.",
+          "Chrome version '%s' is not supported, please upgrade to '%d' or higher",
           chrome_version,
           required_version
         )

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -249,6 +249,10 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
           self$active_filters_ns()
         )
       )
+
+      self$log_message(sprintf("Value for displayed_datasets_index: %s", toString(available_datasets)))
+      self$log_message(sprintf("Value for available_datasets: %s", toString(displayed_datasets_index)))
+
       available_datasets[displayed_datasets_index]
     },
     #' @description

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -250,8 +250,8 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         )
       )
 
-      self$log_message(sprintf("Value for displayed_datasets_index: %s", toString(available_datasets)))
-      self$log_message(sprintf("Value for available_datasets: %s", toString(displayed_datasets_index)))
+      self$log_message(sprintf("Value for displayed_datasets_index: %s", toString(displayed_datasets_index)))
+      self$log_message(sprintf("Value for available_datasets: %s", toString(available_datasets)))
 
       available_datasets[displayed_datasets_index]
     },

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -268,7 +268,13 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       checkmate::assert_flag(content_visibility_auto)
       checkmate::assert_flag(opacity_property)
       checkmate::assert_flag(visibility_property)
-      result <- unlist(
+
+      testthat::skip_if(
+        app$get_js("typeof Element.prototype.checkVisibility === 'function'"),
+        "Element.prototype.checkVisibility is not supported in the current browser."
+      )
+
+      unlist(
         self$get_js(
           sprintf(
             "Array.from(document.querySelectorAll('%s')).map(el => el.checkVisibility({%s, %s, %s}))",
@@ -280,22 +286,6 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
           )
         )
       )
-
-      # Fallback if chrome/chromium doesn't support el.checkVisibility (< 105)
-      if (all(vapply(result, is.null, logical(1)))) {
-        fun_body <- "elem => !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)"
-        unlist(
-          self$get_js(
-            sprintf(
-              "Array.from(document.querySelectorAll('%s')).map(%s)",
-              selector,
-              fun_body
-            )
-          )
-        )
-      } else {
-        result
-      }
     },
     #' @description
     #' Get the active filter variables from a dataset in the `teal` app.

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -297,7 +297,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       checkmate::assert_flag(visibility_property)
 
       testthat::skip_if_not(
-        app$get_js("typeof Element.prototype.checkVisibility === 'function'"),
+        self$get_js("typeof Element.prototype.checkVisibility === 'function'"),
         "Element.prototype.checkVisibility is not supported in the current browser."
       )
 

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -271,7 +271,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       checkmate::assert_flag(content_visibility_auto)
       checkmate::assert_flag(opacity_property)
       checkmate::assert_flag(visibility_property)
-      unlist(
+      result <- unlist(
         self$get_js(
           sprintf(
             "Array.from(document.querySelectorAll('%s')).map(el => el.checkVisibility({%s, %s, %s}))",
@@ -283,6 +283,22 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
           )
         )
       )
+
+      # Fallback if chrome/chromium doesn't support el.checkVisibility (< 105)
+      if (all(vapply(result, is.null, logical(1)))) {
+        fun_body <- "elem => !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)"
+        unlist(
+          self$get_js(
+            sprintf(
+              "Array.from(document.querySelectorAll('%s')).map(%s)",
+              selector,
+              fun_body
+            )
+          )
+        )
+      } else {
+        result
+      }
     },
     #' @description
     #' Get the active filter variables from a dataset in the `teal` app.

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -76,7 +76,8 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         strict = FALSE
       )
 
-      testthat::skip_if_not(!is.na(chrome_version) && chrome_version >= 105)
+      testthat::skip_if(is.na(chrome_version), "Problem getting Chrome version.")
+      testthat::skip_if(chrome_version < 105, "Chrome version is not supported, please upgrade.")
       # end od check
 
       private$set_active_ns()
@@ -283,7 +284,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       checkmate::assert_flag(opacity_property)
       checkmate::assert_flag(visibility_property)
 
-      testthat::skip_if(
+      testthat::skip_if_not(
         app$get_js("typeof Element.prototype.checkVisibility === 'function'"),
         "Element.prototype.checkVisibility is not supported in the current browser."
       )

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -250,9 +250,6 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         )
       )
 
-      self$log_message(sprintf("Value for displayed_datasets_index: %s", toString(displayed_datasets_index)))
-      self$log_message(sprintf("Value for available_datasets: %s", toString(available_datasets)))
-
       available_datasets[displayed_datasets_index]
     },
     #' @description

--- a/tests/testthat/test-shinytest2-filter_panel.R
+++ b/tests/testthat/test-shinytest2-filter_panel.R
@@ -45,11 +45,11 @@ testthat::test_that("e2e: filtering a module-specific filter is refected in othe
     )
   )
 
-  get_species_filter_values <- app$get_active_data_filters("iris")$Species
+  get_active_filter_vars <- app$get_active_filter_vars()
   print(app$get_logs())
 
   expect_equal(
-    get_species_filter_values,
+    app$get_active_data_filters("iris")$Species,
     c("setosa", "versicolor", "virginica")
   )
 

--- a/tests/testthat/test-shinytest2-filter_panel.R
+++ b/tests/testthat/test-shinytest2-filter_panel.R
@@ -47,6 +47,7 @@ testthat::test_that("e2e: filtering a module-specific filter is refected in othe
 
   get_active_filter_vars <- app$get_active_filter_vars()
   print(app$get_logs())
+  print(app$get_html("#teal-main_ui_container"))
 
   expect_equal(
     app$get_active_data_filters("iris")$Species,

--- a/tests/testthat/test-shinytest2-filter_panel.R
+++ b/tests/testthat/test-shinytest2-filter_panel.R
@@ -45,8 +45,11 @@ testthat::test_that("e2e: filtering a module-specific filter is refected in othe
     )
   )
 
+  get_species_filter_values <- app$get_active_data_filters("iris")$Species
+  print(app$get_logs())
+
   expect_equal(
-    app$get_active_data_filters("iris")$Species,
+    get_species_filter_values,
     c("setosa", "versicolor", "virginica")
   )
 

--- a/tests/testthat/test-shinytest2-filter_panel.R
+++ b/tests/testthat/test-shinytest2-filter_panel.R
@@ -45,10 +45,6 @@ testthat::test_that("e2e: filtering a module-specific filter is refected in othe
     )
   )
 
-  get_active_filter_vars <- app$get_active_filter_vars()
-  print(app$get_logs())
-  print(app$get_html("#teal-main_ui_container"))
-
   testthat::expect_setequal(
     app$get_active_data_filters("iris")$Species,
     c("setosa", "versicolor", "virginica")

--- a/tests/testthat/test-shinytest2-filter_panel.R
+++ b/tests/testthat/test-shinytest2-filter_panel.R
@@ -49,7 +49,7 @@ testthat::test_that("e2e: filtering a module-specific filter is refected in othe
   print(app$get_logs())
   print(app$get_html("#teal-main_ui_container"))
 
-  expect_equal(
+  testthat::expect_setequal(
     app$get_active_data_filters("iris")$Species,
     c("setosa", "versicolor", "virginica")
   )
@@ -60,7 +60,7 @@ testthat::test_that("e2e: filtering a module-specific filter is refected in othe
 
   app$navigate_teal_tab("Module_1")
 
-  expect_equal(
+  testthat::expect_equal(
     app$get_active_data_filters("iris")$Species,
     c("setosa")
   )
@@ -88,10 +88,7 @@ testthat::test_that("e2e: filtering a module-specific filter is not refected in 
     )
   )
 
-  expect_equal(
-    app$get_active_data_filters("mtcars")$cyl,
-    c("4", "6")
-  )
+  testthat::expect_setequal(app$get_active_data_filters("mtcars")$cyl, c("4", "6"))
 
   app$navigate_teal_tab("Module_2")
 
@@ -99,10 +96,7 @@ testthat::test_that("e2e: filtering a module-specific filter is not refected in 
 
   app$navigate_teal_tab("Module_1")
 
-  expect_equal(
-    app$get_active_data_filters("mtcars")$cyl,
-    c("4", "6")
-  )
+  testthat::expect_setequal(app$get_active_data_filters("mtcars")$cyl, c("4", "6"))
 
   app$stop()
 })

--- a/tests/testthat/test-shinytest2-teal_slices.R
+++ b/tests/testthat/test-shinytest2-teal_slices.R
@@ -14,27 +14,27 @@ testthat::test_that("e2e: teal_slices filters are initialized when global filter
     )
   )
 
-  testthat::expect_identical(
+  testthat::expect_setequal(
     names(app$get_active_data_filters("iris")),
     "Species"
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     names(app$get_active_data_filters("mtcars")),
     c("cyl", "drat", "gear")
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("iris")$Species,
     c("setosa", "versicolor", "virginica")
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("mtcars")$cyl,
     c("4", "6")
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("mtcars")$drat,
     c(3, 4)
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("mtcars")$gear,
     c("3", "4", "5")
   )
@@ -62,19 +62,19 @@ testthat::test_that("e2e: teal_slices filters are initialized when module specif
     )
   )
 
-  testthat::expect_identical(
+  testthat::expect_setequal(
     names(app$get_active_data_filters("iris")),
     "Species"
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     names(app$get_active_data_filters("mtcars")),
     "cyl"
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("iris")$Species,
     c("setosa", "versicolor", "virginica")
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("mtcars")$cyl,
     c("4", "6")
   )
@@ -84,23 +84,23 @@ testthat::test_that("e2e: teal_slices filters are initialized when module specif
 
   app$navigate_teal_tab("Module_2")
 
-  testthat::expect_identical(
+  testthat::expect_setequal(
     names(app$get_active_data_filters("iris")),
     "Species"
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     names(app$get_active_data_filters("mtcars")),
     c("drat", "gear")
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("iris")$Species,
     c("setosa", "versicolor", "virginica")
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("mtcars")$drat,
     c(3, 4)
   )
-  testthat::expect_identical(
+  testthat::expect_setequal(
     app$get_active_data_filters("mtcars")$gear,
     c("3", "4", "5")
   )


### PR DESCRIPTION
Related to #1195 

I'm focusing on `test-shinytest2-filter_panel` to gain more insight during the integration test.

#### Changes description

- Use alternative method of checking visibility of element when `el.checkVisibility()` method does not exists (is `null`)
- Fix tests that were relying on the order of unordered filters (categorical)
  - `expect_setequal` instead of `expect_equal` to compare vectors.