### PR TITLE
Extend the table fetcher to handle DT tables too

### DIFF
--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -246,19 +246,19 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #' Get the output from the module's `teal.widgets::table_with_settings` or `DT::DTOutput` in the `teal` app.
     #' This function will only access outputs from the name space of the current active teal module.
     #'
-    #' @param tws (`character(1)`) `table_with_settings` namespace name.
+    #' @param table_id (`character(1)`) The id of the table in the active teal module's name space.
     #' @param which (integer) If there is more than one table, which should be extracted.
     #' @param is_dt_table (logical) If the table is a `DT::DTOutput`.
     #' By default it will look for  a table that is built using `teal.widgets::table_with_settings`.
     #'
     #' @return The data.frame with table contents.
-    get_active_module_table_output = function(tws, which = 1, is_dt_table = FALSE) {
+    get_active_module_table_output = function(table_id, which = 1, is_dt_table = FALSE) {
       checkmate::check_number(which, lower = 1)
-      checkmate::check_string(tws)
+      checkmate::check_string(table_id)
       table_selector <- ifelse(
         is_dt_table,
-        self$active_module_element(tws),
-        self$active_module_element(sprintf("%s-table-with-settings", tws))
+        self$active_module_element(table_id),
+        self$active_module_element(sprintf("%s-table-with-settings", table_id))
       )
       table <- table_selector %>%
         self$get_html_rvest() %>%
@@ -273,13 +273,13 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #' Get the output from the module's `teal.widgets::plot_with_settings` in the `teal` app.
     #' This function will only access plots from the name space of the current active teal module.
     #'
-    #' @param pws (`character(1)`) `plot_with_settings` namespace name.
+    #' @param plot_id (`character(1)`) The id of the plot in the active teal module's name space.
     #'
     #' @return The `src` attribute as `character(1)` vector.
-    get_active_module_plot_output = function(pws) {
-      checkmate::check_string(pws)
+    get_active_module_plot_output = function(plot_id) {
+      checkmate::check_string(plot_id)
       self$get_attr(
-        self$active_module_element(sprintf("%s-plot_main > img", pws)),
+        self$active_module_element(sprintf("%s-plot_main > img", plot_id)),
         "src"
       )
     },

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -248,19 +248,13 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #'
     #' @param table_id (`character(1)`) The id of the table in the active teal module's name space.
     #' @param which (integer) If there is more than one table, which should be extracted.
-    #' @param is_dt_table (logical) If the table is a `DT::DTOutput`.
     #' By default it will look for  a table that is built using `teal.widgets::table_with_settings`.
     #'
     #' @return The data.frame with table contents.
-    get_active_module_table_output = function(table_id, which = 1, is_dt_table = FALSE) {
+    get_active_module_table_output = function(table_id, which = 1) {
       checkmate::check_number(which, lower = 1)
       checkmate::check_string(table_id)
-      table_selector <- ifelse(
-        is_dt_table,
-        self$active_module_element(table_id),
-        self$active_module_element(sprintf("%s-table-with-settings", table_id))
-      )
-      table <- table_selector %>%
+      table <- self$active_module_element(table_id) %>%
         self$get_html_rvest() %>%
         rvest::html_table(fill = TRUE)
       if (length(table) == 0) {

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -243,7 +243,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       self$get_value(output = sprintf("%s-%s", self$active_module_ns(), output_id))
     },
     #' @description
-    #' Get the output from the module's `teal.widgets::table_with_settings` in the `teal` app.
+    #' Get the output from the module's `teal.widgets::table_with_settings` or `DT::DTOutput` in the `teal` app.
     #' This function will only access outputs from the name space of the current active teal module.
     #'
     #' @param tws (`character(1)`) `table_with_settings` namespace name.
@@ -253,13 +253,14 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     get_active_module_tws_output = function(tws, which = 1) {
       checkmate::check_number(which, lower = 1)
       checkmate::check_string(tws)
-      table <-
-        rvest::html_table(
-          self$get_html_rvest(
-            self$active_module_element(sprintf("%s-table-with-settings", tws))
-          ),
-          fill = TRUE
-        )
+      table_selector <- ifelse(
+        is.null(self$is_visible(sprintf("%s table", self$active_module_element(tws)))),
+        self$active_module_element(sprintf("%s-table-with-settings", tws)),
+        sprintf("%s table", self$active_module_element(tws))
+      )
+      table <- table_selector %>%
+        self$get_html_rvest() %>%
+        rvest::html_table(fill = TRUE)
       if (length(table) == 0) {
         data.frame()
       } else {

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -248,13 +248,15 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #'
     #' @param tws (`character(1)`) `table_with_settings` namespace name.
     #' @param which (integer) If there is more than one table, which should be extracted.
+    #' @param is_dt_table (logical) If the table is a `DT::DTOutput`.
+    #' By default it will look for  a table that is built using `teal.widgets::table_with_settings`.
     #'
     #' @return The data.frame with table contents.
-    get_active_module_tws_output = function(tws, which = 1) {
+    get_active_module_table_output = function(tws, which = 1, is_dt_table = FALSE) {
       checkmate::check_number(which, lower = 1)
       checkmate::check_string(tws)
       table_selector <- ifelse(
-        is.null(self$is_visible(self$active_module_element(sprintf("%s-table-with-settings", tws)))),
+        is_dt_table,
         self$active_module_element(tws),
         self$active_module_element(sprintf("%s-table-with-settings", tws))
       )
@@ -274,7 +276,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #' @param pws (`character(1)`) `plot_with_settings` namespace name.
     #'
     #' @return The `src` attribute as `character(1)` vector.
-    get_active_module_pws_output = function(pws) {
+    get_active_module_plot_output = function(pws) {
       checkmate::check_string(pws)
       self$get_attr(
         self$active_module_element(sprintf("%s-plot_main > img", pws)),

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -254,9 +254,9 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       checkmate::check_number(which, lower = 1)
       checkmate::check_string(tws)
       table_selector <- ifelse(
-        is.null(self$is_visible(sprintf("%s table", self$active_module_element(tws)))),
-        self$active_module_element(sprintf("%s-table-with-settings", tws)),
-        sprintf("%s table", self$active_module_element(tws))
+        is.null(self$is_visible(self$active_module_element(sprintf("%s-table-with-settings", tws)))),
+        self$active_module_element(tws),
+        self$active_module_element(sprintf("%s-table-with-settings", tws))
       )
       table <- table_selector %>%
         self$get_html_rvest() %>%

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -357,11 +357,7 @@ The value of the shiny output.
 Get the output from the module's \code{teal.widgets::table_with_settings} or \code{DT::DTOutput} in the \code{teal} app.
 This function will only access outputs from the name space of the current active teal module.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_table_output(
-  table_id,
-  which = 1,
-  is_dt_table = FALSE
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_table_output(table_id, which = 1)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -369,9 +365,7 @@ This function will only access outputs from the name space of the current active
 \describe{
 \item{\code{table_id}}{(\code{character(1)}) The id of the table in the active teal module's name space.}
 
-\item{\code{which}}{(integer) If there is more than one table, which should be extracted.}
-
-\item{\code{is_dt_table}}{(logical) If the table is a \code{DT::DTOutput}.
+\item{\code{which}}{(integer) If there is more than one table, which should be extracted.
 By default it will look for  a table that is built using \code{teal.widgets::table_with_settings}.}
 }
 \if{html}{\out{</div>}}

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -33,8 +33,8 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-active_filters_ns}{\code{TealAppDriver$active_filters_ns()}}
 \item \href{#method-TealAppDriver-get_active_module_input}{\code{TealAppDriver$get_active_module_input()}}
 \item \href{#method-TealAppDriver-get_active_module_output}{\code{TealAppDriver$get_active_module_output()}}
-\item \href{#method-TealAppDriver-get_active_module_tws_output}{\code{TealAppDriver$get_active_module_tws_output()}}
-\item \href{#method-TealAppDriver-get_active_module_pws_output}{\code{TealAppDriver$get_active_module_pws_output()}}
+\item \href{#method-TealAppDriver-get_active_module_table_output}{\code{TealAppDriver$get_active_module_table_output()}}
+\item \href{#method-TealAppDriver-get_active_module_plot_output}{\code{TealAppDriver$get_active_module_plot_output()}}
 \item \href{#method-TealAppDriver-set_active_module_input}{\code{TealAppDriver$set_active_module_input()}}
 \item \href{#method-TealAppDriver-get_active_filter_vars}{\code{TealAppDriver$get_active_filter_vars()}}
 \item \href{#method-TealAppDriver-is_visible}{\code{TealAppDriver$is_visible()}}
@@ -351,13 +351,17 @@ The value of the shiny output.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TealAppDriver-get_active_module_tws_output"></a>}}
-\if{latex}{\out{\hypertarget{method-TealAppDriver-get_active_module_tws_output}{}}}
-\subsection{Method \code{get_active_module_tws_output()}}{
+\if{html}{\out{<a id="method-TealAppDriver-get_active_module_table_output"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-get_active_module_table_output}{}}}
+\subsection{Method \code{get_active_module_table_output()}}{
 Get the output from the module's \code{teal.widgets::table_with_settings} or \code{DT::DTOutput} in the \code{teal} app.
 This function will only access outputs from the name space of the current active teal module.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_tws_output(tws, which = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_table_output(
+  tws,
+  which = 1,
+  is_dt_table = FALSE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -366,6 +370,9 @@ This function will only access outputs from the name space of the current active
 \item{\code{tws}}{(\code{character(1)}) \code{table_with_settings} namespace name.}
 
 \item{\code{which}}{(integer) If there is more than one table, which should be extracted.}
+
+\item{\code{is_dt_table}}{(logical) If the table is a \code{DT::DTOutput}.
+By default it will look for  a table that is built using \code{teal.widgets::table_with_settings}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -374,13 +381,13 @@ The data.frame with table contents.
 }
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TealAppDriver-get_active_module_pws_output"></a>}}
-\if{latex}{\out{\hypertarget{method-TealAppDriver-get_active_module_pws_output}{}}}
-\subsection{Method \code{get_active_module_pws_output()}}{
+\if{html}{\out{<a id="method-TealAppDriver-get_active_module_plot_output"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-get_active_module_plot_output}{}}}
+\subsection{Method \code{get_active_module_plot_output()}}{
 Get the output from the module's \code{teal.widgets::plot_with_settings} in the \code{teal} app.
 This function will only access plots from the name space of the current active teal module.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_pws_output(pws)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_plot_output(pws)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -354,7 +354,7 @@ The value of the shiny output.
 \if{html}{\out{<a id="method-TealAppDriver-get_active_module_tws_output"></a>}}
 \if{latex}{\out{\hypertarget{method-TealAppDriver-get_active_module_tws_output}{}}}
 \subsection{Method \code{get_active_module_tws_output()}}{
-Get the output from the module's \code{teal.widgets::table_with_settings} in the \code{teal} app.
+Get the output from the module's \code{teal.widgets::table_with_settings} or \code{DT::DTOutput} in the \code{teal} app.
 This function will only access outputs from the name space of the current active teal module.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_tws_output(tws, which = 1)}\if{html}{\out{</div>}}

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -358,7 +358,7 @@ Get the output from the module's \code{teal.widgets::table_with_settings} or \co
 This function will only access outputs from the name space of the current active teal module.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_table_output(
-  tws,
+  table_id,
   which = 1,
   is_dt_table = FALSE
 )}\if{html}{\out{</div>}}
@@ -367,7 +367,7 @@ This function will only access outputs from the name space of the current active
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{tws}}{(\code{character(1)}) \code{table_with_settings} namespace name.}
+\item{\code{table_id}}{(\code{character(1)}) The id of the table in the active teal module's name space.}
 
 \item{\code{which}}{(integer) If there is more than one table, which should be extracted.}
 
@@ -387,13 +387,13 @@ The data.frame with table contents.
 Get the output from the module's \code{teal.widgets::plot_with_settings} in the \code{teal} app.
 This function will only access plots from the name space of the current active teal module.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_plot_output(pws)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_module_plot_output(plot_id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{pws}}{(\code{character(1)}) \code{plot_with_settings} namespace name.}
+\item{\code{plot_id}}{(\code{character(1)}) The id of the plot in the active teal module's name space.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/teal_slices.Rd
+++ b/man/teal_slices.Rd
@@ -22,8 +22,7 @@ as.teal_slices(x)
 \method{c}{teal_slices}(...)
 }
 \arguments{
-\item{...}{any number of \code{teal_slice} objects. For \code{print} and \code{format},
-additional arguments passed to other functions.}
+\item{...}{any number of \code{teal_slice} objects.}
 
 \item{include_varnames, exclude_varnames}{(\verb{named list}s of \code{character}) where list names
 match names of data sets and vector elements match variable names in respective data sets;


### PR DESCRIPTION
Extend the `get_active_module_tws_output` to also work for `DT::DTOutput` which is now renamed to `get_active_module_table_output` along with `get_active_module_plot_output`

Example to test:

```r
devtools::load_all("../teal")
library(teal.modules.clinical)

data <- teal_data()
data <- within(data, {
  ADSL <- teal.data::rADSL
  ADLB <- teal.data::rADLB
})

datanames <- c("ADSL", "ADLB")
teal.data::datanames(data) <- datanames
teal.data::join_keys(data) <- teal.data::default_cdisc_join_keys[datanames]

app_driver <- TealAppDriver$new(
  data = data,
  modules = tm_t_pp_laboratory(
    label = "Vitals",
    dataname = "ADLB",
    patient_col = "USUBJID",
    paramcd = teal.transform::choices_selected(
      choices = teal.transform::variable_choices(data[["ADLB"]], "PARAMCD"),
      selected = "PARAMCD"
    ),
    param = teal.transform::choices_selected(
      choices = teal.transform::variable_choices(data[["ADLB"]], "PARAM"),
      selected = "PARAM"
    ),
    timepoints = teal.transform::choices_selected(
      choices = teal.transform::variable_choices(data[["ADLB"]], "ADY"),
      selected = "ADY"
    ),
    anrind = teal.transform::choices_selected(
      choices = teal.transform::variable_choices(data[["ADLB"]], "ANRIND"),
      selected = "ANRIND"
    ),
    aval_var = teal.transform::choices_selected(
      choices = teal.transform::variable_choices(data[["ADLB"]], "AVAL"),
      selected = "AVAL"
    ),
    avalu_var = teal.transform::choices_selected(
      choices = teal.transform::variable_choices(data[["ADLB"]], "AVALU"),
      selected = "AVALU"
    )
  )
)

app_driver$get_active_module_table_output("lab_values_table", 2)
```