### PR TITLE
Fix shinytest2 app init on R 4.4.0+

### DIFF
--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -76,7 +76,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         strict = FALSE
       )
 
-      required_version <- 105
+      required_version <- "105"
 
       testthat::skip_if(
         is.na(chrome_version),
@@ -85,7 +85,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       testthat::skip_if(
         chrome_version < required_version,
         sprintf(
-          "Chrome version '%s' is not supported, please upgrade to '%d' or higher",
+          "Chrome version '%s' is not supported, please upgrade to '%s' or higher",
           chrome_version,
           required_version
         )


### PR DESCRIPTION
Fixes the broken [shinytest2 tests](https://github.com/insightsengineering/teal/actions/runs/8961636987/job/24609457272)

The root cause is that `numeric_version` only accepts character to convert into `numeric_version` class. So typecasting of the numeric version was giving the error.

Example code to test. This works in older R versions. But, in R 4.4.0 it does not work.
```r
# Broken
numeric_version('123') > 120

#Works
numeric_version('123') > '120'
```
