### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Suggests:
     knitr (>= 1.42),
     MultiAssayExperiment,
     R6,
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     rvest,
     shinytest2,
     shinyvalidate,


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.