### PR TITLE
A method to check for page stability when shiny is not busy

### DIFF
--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -336,6 +336,9 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         "Element.prototype.checkVisibility is not supported in the current browser."
       )
 
+      # Check if no UI updates are made in the page for 0.5 seconds.
+      self$wait_for_element_stability(element_selector = "body", stability_period = 500, check_interval = 50)
+
       unlist(
         self$get_js(
           sprintf(
@@ -576,11 +579,16 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         ...
       )
     },
-    wait_for_element_stability = function(element_selector = "body", stability_period = 1000, check_interval = 100) {
+    #' @description
+    #' Check if the page is stable without any DOM updates for the specified stability period.
+    #' @param element_selector (`character(1)`) `CSS` selector to check the stability of the page.
+    #' @param stability_period (`numeric(1)`) The time in milliseconds to wait for the page to be stable.
+    #' @param check_interval (`numeric(1)`) The time in milliseconds to check for changes in the page.
+    #' The stability check is reset when a change is detected in the page after sleeping for check_interval.
+    #' Parameter with additional value to passed in `wait_for_value`.
+    wait_for_element_stability = function(element_selector = "body", stability_period = 500, check_interval = 50) {
       element_content <- self$get_html(element_selector)
       times_run <- 0
-      check_interval <- 100
-      stability_period <- 1000
       max_times_run <- stability_period / check_interval
 
       while (TRUE) {
@@ -591,7 +599,6 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         } else if (times_run < max_times_run) {
           times_run <- times_run + 1
         } else {
-          print("Page is stable now!")
           break
         }
         Sys.sleep(check_interval / 1000)

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -338,9 +338,6 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         "Element.prototype.checkVisibility is not supported in the current browser."
       )
 
-      # Check if no UI updates are made in the page for 0.5 seconds.
-      self$wait_for_element_stability(element_selector = "body", stability_period = 500, check_interval = 50)
-
       unlist(
         self$get_js(
           sprintf(
@@ -653,6 +650,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     },
     #' @description
     #' Check if the page is stable without any `DOM` updates in the body of the app.
+    #' This is achieved by blocing the R process by sleeping until the page is unchanged till the `stability_period`.
     #' @param stability_period (`numeric(1)`) The time in milliseconds to wait till the page to be stable.
     #' @param check_interval (`numeric(1)`) The time in milliseconds to check for changes in the page.
     #' The stability check is reset when a change is detected in the page after sleeping for check_interval.

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -580,7 +580,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       )
     },
     #' @description
-    #' Check if the page is stable without any DOM updates for the specified stability period.
+    #' Check if the page is stable without any `DOM` updates for the specified stability period.
     #' @param element_selector (`character(1)`) `CSS` selector to check the stability of the page.
     #' @param stability_period (`numeric(1)`) The time in milliseconds to wait for the page to be stable.
     #' @param check_interval (`numeric(1)`) The time in milliseconds to check for changes in the page.
@@ -594,7 +594,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       while (TRUE) {
         current_element <- self$get_html(element_selector)
         if (!identical(current_element, element_content)) {
-          element_content <- current_inner_html
+          element_content <- current_element
           times_run <- 0
         } else if (times_run < max_times_run) {
           times_run <- times_run + 1

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -652,26 +652,24 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       NULL # If there are not any supported filters
     },
     #' @description
-    #' Check if the page is stable without any `DOM` updates for the specified stability period.
+    #' Check if the page is stable without any `DOM` updates in the body of the app.
     #' @param stability_period (`numeric(1)`) The time in milliseconds to wait till the page to be stable.
     #' @param check_interval (`numeric(1)`) The time in milliseconds to check for changes in the page.
     #' The stability check is reset when a change is detected in the page after sleeping for check_interval.
     wait_for_page_stability = function(stability_period = 500, check_interval = 50) {
-      element_content <- self$get_html("body")
-      times_run <- 0
-      max_times_run <- stability_period / check_interval
+      previous_content <- self$get_html("body")
+      end_time <- Sys.time() + (stability_period / 1000)
 
-      while (TRUE) {
-        current_element <- self$get_html("body")
-        if (!identical(current_element, element_content)) {
-          element_content <- current_element
-          times_run <- 0
-        } else if (times_run < max_times_run) {
-          times_run <- times_run + 1
-        } else {
+      repeat {
+        Sys.sleep(check_interval / 1000)
+        current_content <- self$get_html("body")
+
+        if (!identical(previous_content, current_content)) {
+          previous_content <- current_content
+          end_time <- Sys.time() + (stability_period / 1000)
+        } else if (Sys.time() >= end_time) {
           break
         }
-        Sys.sleep(check_interval / 1000)
       }
     }
   )

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -575,6 +575,27 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         export = export,
         ...
       )
+    },
+    wait_for_element_stability = function(element_selector = "body", stability_period = 1000, check_interval = 100) {
+      element_content <- self$get_html(element_selector)
+      times_run <- 0
+      check_interval <- 100
+      stability_period <- 1000
+      max_times_run <- stability_period / check_interval
+
+      while (TRUE) {
+        current_element <- self$get_html(element_selector)
+        if (!identical(current_element, element_content)) {
+          element_content <- current_inner_html
+          times_run <- 0
+        } else if (times_run < max_times_run) {
+          times_run <- times_run + 1
+        } else {
+          print("Page is stable now!")
+          break
+        }
+        Sys.sleep(check_interval / 1000)
+      }
     }
   ),
   # private members ----

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -648,12 +648,12 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
 
       NULL # If there are not any supported filters
     },
-    #' @description
-    #' Check if the page is stable without any `DOM` updates in the body of the app.
-    #' This is achieved by blocing the R process by sleeping until the page is unchanged till the `stability_period`.
-    #' @param stability_period (`numeric(1)`) The time in milliseconds to wait till the page to be stable.
-    #' @param check_interval (`numeric(1)`) The time in milliseconds to check for changes in the page.
-    #' The stability check is reset when a change is detected in the page after sleeping for check_interval.
+    # @description
+    # Check if the page is stable without any `DOM` updates in the body of the app.
+    # This is achieved by blocing the R process by sleeping until the page is unchanged till the `stability_period`.
+    # @param stability_period (`numeric(1)`) The time in milliseconds to wait till the page to be stable.
+    # @param check_interval (`numeric(1)`) The time in milliseconds to check for changes in the page.
+    # The stability check is reset when a change is detected in the page after sleeping for check_interval.
     wait_for_page_stability = function(stability_period = 500, check_interval = 50) {
       previous_content <- self$get_html("body")
       end_time <- Sys.time() + (stability_period / 1000)

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -46,7 +46,6 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-get_html_rvest}{\code{TealAppDriver$get_html_rvest()}}
 \item \href{#method-TealAppDriver-open_url}{\code{TealAppDriver$open_url()}}
 \item \href{#method-TealAppDriver-wait_for_active_module_value}{\code{TealAppDriver$wait_for_active_module_value()}}
-\item \href{#method-TealAppDriver-wait_for_element_stability}{\code{TealAppDriver$wait_for_element_stability()}}
 \item \href{#method-TealAppDriver-clone}{\code{TealAppDriver$clone()}}
 }
 }
@@ -630,33 +629,6 @@ providing a more flexible interface for waiting on different types of values wit
 Only one of these parameters may be used.}
 
 \item{\code{...}}{Must be empty. Allows for parameter expansion.
-Parameter with additional value to passed in \code{wait_for_value}.}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TealAppDriver-wait_for_element_stability"></a>}}
-\if{latex}{\out{\hypertarget{method-TealAppDriver-wait_for_element_stability}{}}}
-\subsection{Method \code{wait_for_element_stability()}}{
-Check if the page is stable without any DOM updates for the specified stability period.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$wait_for_element_stability(
-  element_selector = "body",
-  stability_period = 500,
-  check_interval = 50
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{element_selector}}{(\code{character(1)}) \code{CSS} selector to check the stability of the page.}
-
-\item{\code{stability_period}}{(\code{numeric(1)}) The time in milliseconds to wait for the page to be stable.}
-
-\item{\code{check_interval}}{(\code{numeric(1)}) The time in milliseconds to check for changes in the page.
-The stability check is reset when a change is detected in the page after sleeping for check_interval.
 Parameter with additional value to passed in \code{wait_for_value}.}
 }
 \if{html}{\out{</div>}}

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -46,6 +46,7 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-get_html_rvest}{\code{TealAppDriver$get_html_rvest()}}
 \item \href{#method-TealAppDriver-open_url}{\code{TealAppDriver$open_url()}}
 \item \href{#method-TealAppDriver-wait_for_active_module_value}{\code{TealAppDriver$wait_for_active_module_value()}}
+\item \href{#method-TealAppDriver-wait_for_element_stability}{\code{TealAppDriver$wait_for_element_stability()}}
 \item \href{#method-TealAppDriver-clone}{\code{TealAppDriver$clone()}}
 }
 }
@@ -629,6 +630,33 @@ providing a more flexible interface for waiting on different types of values wit
 Only one of these parameters may be used.}
 
 \item{\code{...}}{Must be empty. Allows for parameter expansion.
+Parameter with additional value to passed in \code{wait_for_value}.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TealAppDriver-wait_for_element_stability"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-wait_for_element_stability}{}}}
+\subsection{Method \code{wait_for_element_stability()}}{
+Check if the page is stable without any DOM updates for the specified stability period.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$wait_for_element_stability(
+  element_selector = "body",
+  stability_period = 500,
+  check_interval = 50
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{element_selector}}{(\code{character(1)}) \code{CSS} selector to check the stability of the page.}
+
+\item{\code{stability_period}}{(\code{numeric(1)}) The time in milliseconds to wait for the page to be stable.}
+
+\item{\code{check_interval}}{(\code{numeric(1)}) The time in milliseconds to check for changes in the page.
+The stability check is reset when a change is detected in the page after sleeping for check_interval.
 Parameter with additional value to passed in \code{wait_for_value}.}
 }
 \if{html}{\out{</div>}}


### PR DESCRIPTION
Introduces a private method for `TealAppDriver` called `wait_for_page_stability` which blocks the R process by sleeping until the page is unchanged till the stability period.

This is used in two places:
1. After a click is performed.
2. Before the visibility is checked.

This should potentially fix the CI errors in tmg and tmc.

Error in tmg:
```r
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Error ('test-shinytest2-tm_misssing_data.R:73:3'): e2e - tm_missing_data: Default settings and visibility of the summary graph ──
  Error in `app_wait_for_idle(self, private, duration = duration, timeout = timeout)`: An error occurred while waiting for Shiny to be stable
  Backtrace:
      ▆
   1. └─app_driver$click(selector = app_driver$active_module_element("iris-filter_na")) at test-shinytest2-tm_misssing_data.R:73:3
   2.   └─self$wait_for_idle()
   3.     └─shinytest2:::app_wait_for_idle(self, private, duration = duration, timeout = timeout)
   4.       └─shinytest2:::app_abort(self, private, "An error occurred while waiting for Shiny to be stable")
   5.         └─rlang::abort(..., app = self, call = call)
  ── Error ('test-shinytest2-tm_misssing_data.R:123:3'): e2e - tm_missing_data: Validate functionality and UI response for 'By Variable Levels' ──
  Error in `app_wait_for_idle(self, private, duration = duration, timeout = timeout)`: An error occurred while waiting for Shiny to be stable
  Backtrace:
      ▆
   1. └─app_driver$set_active_module_input("iris-summary_type", "By Variable Levels") at test-shinytest2-tm_misssing_data.R:123:3
   2.   └─self$wait_for_idle()
   3.     └─shinytest2:::app_wait_for_idle(self, private, duration = duration, timeout = timeout)
   4.       └─shinytest2:::app_abort(self, private, "An error occurred while waiting for Shiny to be stable")
   5.         └─rlang::abort(..., app = self, call = call)
  
  [ FAIL 2 | WARN 5 | SKIP 0 | PASS 464 ]
```

Error in tmc:
```r
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure ('test-shinytest2-tm_t_pp_basic_info.R:78:5'): e2e - tm_t_pp_basic_info: Deselection of patient_id throws validation error and table is not visible. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_basic_info.R:118:3'): e2e - tm_t_pp_basic_info: Deselection of cov_var throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_laboratory.R:129:3'): e2e - tm_t_pp_laboratory: Deselection of patient_id throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_laboratory.R:166:3'): e2e - tm_t_pp_laboratory: Deselection of paramcd throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_laboratory.R:205:5'): e2e - tm_t_pp_laboratory: Deselection of param throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_laboratory.R:243:3'): e2e - tm_t_pp_laboratory: Deselection of timepoints throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_laboratory.R:282:3'): e2e - tm_t_pp_laboratory: Deselection of avalu throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_laboratory.R:321:3'): e2e - tm_t_pp_laboratory: Deselection of aval_var throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  ── Failure ('test-shinytest2-tm_t_pp_laboratory.R:358:3'): e2e - tm_t_pp_laboratory: Deselection of arind throws validation error. ──
  app_driver$is_visible(...) is not FALSE
  
  `actual`:   TRUE 
  `expected`: FALSE
  
  [ FAIL 9 | WARN 8 | SKIP 0 | PASS 1966 ]
```