### PR TITLE
Fix the integration tests by alternative 

### DIFF
--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -338,36 +338,18 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         "Element.prototype.checkVisibility is not supported in the current browser."
       )
 
-      if (visibility_property) {
-        visibility <- unlist(
-          self$get_js(
-            sprintf(
-              "var selector = '%s';
-              var elements = document.querySelectorAll(selector);
-              var visibilityList = [];
-              elements.forEach(function(element) {
-                var computedStyles = window.getComputedStyle(element);
-                visibilityList.push(computedStyles.visibility !== 'hidden');
-              });
-              visibilityList;",
-              selector
-            )
+      unlist(
+        self$get_js(
+          sprintf(
+            "Array.from(document.querySelectorAll('%s')).map(el => el.checkVisibility({%s, %s, %s}))",
+            selector,
+            # Extra parameters
+            sprintf("contentVisibilityAuto: %s", tolower(content_visibility_auto)),
+            sprintf("opacityProperty: %s", tolower(opacity_property)),
+            sprintf("visibilityProperty: %s", tolower(visibility_property))
           )
         )
-      } else {
-        visibility <- unlist(
-          self$get_js(
-            sprintf(
-              "Array.from(document.querySelectorAll('%s')).map(el => el.checkVisibility({%s, %s}))",
-              selector,
-              # Extra parameters
-              sprintf("contentVisibilityAuto: %s", tolower(content_visibility_auto)),
-              sprintf("opacityProperty: %s", tolower(opacity_property))
-            )
-          )
-        )
-      }
-      visibility
+      )
     },
     #' @description
     #' Get the active filter variables from a dataset in the `teal` app.

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -76,7 +76,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         strict = FALSE
       )
 
-      required_version <- "105"
+      required_version <- "121"
 
       testthat::skip_if(
         is.na(chrome_version),

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -672,7 +672,7 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     # @param stability_period (`numeric(1)`) The time in milliseconds to wait till the page to be stable.
     # @param check_interval (`numeric(1)`) The time in milliseconds to check for changes in the page.
     # The stability check is reset when a change is detected in the page after sleeping for check_interval.
-    wait_for_page_stability = function(stability_period = 500, check_interval = 50) {
+    wait_for_page_stability = function(stability_period = 2000, check_interval = 200) {
       previous_content <- self$get_html("body")
       end_time <- Sys.time() + (stability_period / 1000)
 

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -338,18 +338,36 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
         "Element.prototype.checkVisibility is not supported in the current browser."
       )
 
-      unlist(
-        self$get_js(
-          sprintf(
-            "Array.from(document.querySelectorAll('%s')).map(el => el.checkVisibility({%s, %s, %s}))",
-            selector,
-            # Extra parameters
-            sprintf("contentVisibilityAuto: %s", tolower(content_visibility_auto)),
-            sprintf("opacityProperty: %s", tolower(opacity_property)),
-            sprintf("visibilityProperty: %s", tolower(visibility_property))
+      if (visibility_property) {
+        visibility <- unlist(
+          self$get_js(
+            sprintf(
+              "var selector = '%s';
+              var elements = document.querySelectorAll(selector);
+              var visibilityList = [];
+              elements.forEach(function(element) {
+                var computedStyles = window.getComputedStyle(element);
+                visibilityList.push(computedStyles.visibility !== 'hidden');
+              });
+              visibilityList;",
+              selector
+            )
           )
         )
-      )
+      } else {
+        visibility <- unlist(
+          self$get_js(
+            sprintf(
+              "Array.from(document.querySelectorAll('%s')).map(el => el.checkVisibility({%s, %s}))",
+              selector,
+              # Extra parameters
+              sprintf("contentVisibilityAuto: %s", tolower(content_visibility_auto)),
+              sprintf("opacityProperty: %s", tolower(opacity_property))
+            )
+          )
+        )
+      }
+      visibility
     },
     #' @description
     #' Get the active filter variables from a dataset in the `teal` app.


### PR DESCRIPTION
Closes https://github.com/insightsengineering/coredev-tasks/issues/554

Changes:

1. ~The container in the integration test does not seem to evaluate the JS code to check visibility when `app_driver$is_visible` is called with `visibility_property = TRUE`~ Bumping the chrome version to resolve this issue.
2. Increasing the timeout threshold for `wait_for_page_stability`. For an unknown reason this timeout does not work in certain containers. Initial timeout (500ms) was set as a 2x of what was needed in my local machine. But looks like we need at least 800 ms to work in some loaded conditions. So, setting it to 2000 ms now.
