### PR TITLE
modify hideSidebar and showSidebar funcitons to work in embedded apps

### DIFF
--- a/inst/js/sidebar.js
+++ b/inst/js/sidebar.js
@@ -1,12 +1,18 @@
 // used to collapse and expand the filter panel in teal apps
+/*
+resize is placed at end of functions
+b/c in embedded apps it will throw errors that cause the function to exit early
+*/
 var filter_open = true;
 const hideSidebar = () => {
-  $(".teal_secondary_col").fadeOut(1);
-  $(".teal_primary_col").attr("class", "teal_primary_col col-sm-12").resize();
+  $(".teal_secondary_col").css("display", "none");
+  $(".teal_primary_col").attr("class", "teal_primary_col col-sm-12");
+  $(".teal_primary_col").resize();
 };
 const showSidebar = () => {
-  $(".teal_primary_col").attr("class", "teal_primary_col col-sm-9").resize();
-  $(".teal_secondary_col").delay(600).fadeIn(50);
+  $(".teal_primary_col").attr("class", "teal_primary_col col-sm-9");
+  $(".teal_secondary_col").css("display", "block");
+  $(".teal_primary_col").resize();
 };
 const toggleFilterPanel = () => {
   if (filter_open && !$(".teal_secondary_col").is(':visible')) {


### PR DESCRIPTION
#### BACKGROUND
I am trying to embed a `teal` app in a `shiny` app (`shiny` is parent and `teal` is child). I want to be able to go back and forth between configuring the `teal` app and inspecting it. 

The `teal` app is created by calling `module_teal_with_splash`, with `ui_teal_with_splash` placed in a `renderUI` call and `shinyjs::hidden`. When configutraion is ready, an action button runs `shonyjs::show` on the module UI and calls the module server function. When the user wants to go back to configuration, the child app is hidden again. A new child is run with a different, incremented id.

#### PROBLEM
I am having some trouble with the filter panel that result from the current implementation of `showSidebar` and `hideSidebar` causes some problems. 

Over a single session of the parent app, when the child is rendered for the first time, the filter panel can be toggled normally. However, when I generate the child app for the second time, the JS console throws an error and toggling is no longer possible. The filter panel is expanded but invisible because it retains `display: none`.

#### NOTE
The bug is only triggered by modules that contain plots. Modules with tables or simple prints (like `example_module` or `tm_t_crosstable`) work just fine but once the bug is triggerred, those too are affected.

#### SOLUTION
I modified the script that toggles the filter panel to get around the issue.

1. The `resize` method throws an error (even thought the resizing does occur) so `showSidebar` exits early and `fadeIn` does not kick in. I moved `resize` to the end of the function.
2. There seems to be a conflict between `$(".teal_secondary_col").fadeIn(50)` and `$(".teal_primary_col").resize()` that prevents resizing. I replaced `fadeOut/In` with adding/removing `display; none`.
