### PR TITLE
decouple `teal.widgets` from `teal` in plot resizing

### DIFF
--- a/inst/js/sidebar.js
+++ b/inst/js/sidebar.js
@@ -5,22 +5,12 @@ b/c in embedded apps it will throw errors that cause the function to exit early
 */
 var filter_open = true;
 const hideSidebar = () => {
-  $(".teal_secondary_col").css("display", "none");
-  $(".teal_primary_col")
-    .removeClass("col-sm-9")
-    .addClass("col-sm-12");
-  $(".teal_primary_col").trigger("resize");
+  $(".teal_secondary_col").fadeOut(1);
+  $(".teal_primary_col").removeClass("col-sm-9").addClass("col-sm-12");
 };
 const showSidebar = () => {
-  $(".teal_primary_col")
-    .removeClass("col-sm-12")
-    .addClass("col-sm-9");
-  setTimeout(
-    () => {
-      $(".teal_secondary_col").css("display", "block");
-    },
-    600);
-  $(".teal_primary_col").trigger("resize");
+  $(".teal_primary_col").removeClass("col-sm-12").addClass("col-sm-9");
+  $(".teal_secondary_col").delay(600).fadeIn(50);
 };
 const toggleFilterPanel = () => {
   if (filter_open && !$(".teal_secondary_col").is(':visible')) {

--- a/inst/js/sidebar.js
+++ b/inst/js/sidebar.js
@@ -1,8 +1,4 @@
 // used to collapse and expand the filter panel in teal apps
-/*
-resize is placed at end of functions
-b/c in embedded apps it will throw errors that cause the function to exit early
-*/
 var filter_open = true;
 const hideSidebar = () => {
   $(".teal_secondary_col").fadeOut(1);

--- a/inst/js/sidebar.js
+++ b/inst/js/sidebar.js
@@ -6,7 +6,7 @@ const hideSidebar = () => {
 };
 const showSidebar = () => {
   $(".teal_primary_col").removeClass("col-sm-12").addClass("col-sm-9");
-  $(".teal_secondary_col").delay(600).fadeIn(50);
+  $(".teal_secondary_col").fadeIn(650);
 };
 const toggleFilterPanel = () => {
   if (filter_open && !$(".teal_secondary_col").is(':visible')) {


### PR DESCRIPTION
Companion to https://github.com/insightsengineering/teal.widgets/pull/250

Removed `.trigger("resize")` call as resizing is now handled solely by `teal.widgets`.
Removed async delay in `showSidebar` in favor of `fadeIn`.