### PR TITLE
`{shinytest2}` and `shiny::testServer` tests for `data_summary` panel

### DIFF
--- a/R/1.0_module_data_summary.R
+++ b/R/1.0_module_data_summary.R
@@ -77,25 +77,19 @@ srv_data_summary <- function(id, teal_data) {
         filter_overview <- get_filter_overview(teal_data)
         attr(filter_overview$dataname, "label") <- "Data Name"
 
-        if (!is.null(filter_overview$obs)) {
-          # some datasets (MAE colData) doesn't return obs column
-          filter_overview$obs_str_summary <- ifelse(
-            !is.na(filter_overview$obs),
-            sprintf("%s/%s", filter_overview$obs_filtered, filter_overview$obs),
-            ""
-          )
-          attr(filter_overview$obs_str_summary, "label") <- "Obs"
-        }
+        filter_overview$obs_str_summary <- ifelse(
+          !is.na(filter_overview$obs),
+          sprintf("%s/%s", filter_overview$obs_filtered, filter_overview$obs),
+          ""
+        )
+        attr(filter_overview$obs_str_summary, "label") <- "Obs"
 
-        if (!is.null(filter_overview$subjects)) {
-          # some datasets (without keys) doesn't return subjects
-          filter_overview$subjects_summary <- ifelse(
-            !is.na(filter_overview$subjects),
-            sprintf("%s/%s", filter_overview$subjects_filtered, filter_overview$subjects),
-            ""
-          )
-          attr(filter_overview$subjects_summary, "label") <- "Subjects"
-        }
+        filter_overview$subjects_summary <- ifelse(
+          !is.na(filter_overview$subjects),
+          sprintf("%s/%s", filter_overview$subjects_filtered, filter_overview$subjects),
+          ""
+        )
+        attr(filter_overview$subjects_summary, "label") <- "Subjects"
 
         all_names <- c("dataname", "obs_str_summary", "subjects_summary")
         filter_overview <- filter_overview[, colnames(filter_overview) %in% all_names]

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -339,8 +339,8 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
     #' @return `data.frame`
     get_active_data_summary_table = function() {
      summary_table <-
-        app$active_data_summary_element('table') %>%
-        app$get_html_rvest() %>%
+        self$active_data_summary_element('table') %>%
+        self$get_html_rvest() %>%
         rvest::html_table(fill = TRUE) %>%
         .[[1]]
 

--- a/R/TealAppDriver.R
+++ b/R/TealAppDriver.R
@@ -221,6 +221,26 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       private$ns$filter_panel
     },
     #' @description
+    #' Get the active shiny name space for interacting with the data-summary panel.
+    #'
+    #' @return (`string`) The active shiny name space of the data-summary component.
+    active_data_summary_ns = function() {
+      if (identical(private$ns$data_summary, character(0))) {
+        private$set_active_ns()
+      }
+      private$ns$data_summary
+    },
+    #' @description
+    #' Get the active shiny name space bound with a custom `element` name.
+    #'
+    #' @param element `character(1)` custom element name.
+    #'
+    #' @return (`string`) The active shiny name space of the component bound with the input `element`.
+    active_data_summary_element = function(element) {
+      checkmate::assert_string(element)
+      sprintf("#%s-%s", self$active_data_summary_ns(), element)
+    },
+    #' @description
     #' Get the input from the module in the `teal` app.
     #' This function will only access inputs from the name space of the current active teal module.
     #'
@@ -313,6 +333,25 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       )
 
       available_datasets[displayed_datasets_index]
+    },
+    #' @description
+    #' Get the active data summary table
+    #' @return `data.frame`
+    get_active_data_summary_table = function() {
+     summary_table <-
+        app$active_data_summary_element('table') %>%
+        app$get_html_rvest() %>%
+        rvest::html_table(fill = TRUE) %>%
+        .[[1]]
+
+      col_names <- unlist(summary_table[1, ], use.names = FALSE)
+      summary_table <- summary_table[-1, ]
+      colnames(summary_table) <- col_names
+      if (nrow(summary_table) > 0) {
+        summary_table
+      } else {
+        NULL
+      }
     },
     #' @description
     #' Test if `DOM` elements are visible on the page with a JavaScript call.
@@ -613,11 +652,14 @@ TealAppDriver <- R6::R6Class( # nolint: object_name.
       }
       private$ns$module <- sprintf("%s-%s", active_ns, "module")
 
-      component <- "filter_panel"
-      if (!is.null(self$get_html(sprintf("#%s-%s-panel", active_ns, component)))) {
-        private$ns[[component]] <- sprintf("%s-%s", active_ns, component)
-      } else {
-        private$ns[[component]] <- sprintf("%s-module_%s", active_ns, component)
+      components <- c("filter_panel", "data_summary")
+      for (component in components) {
+        if (!is.null(self$get_html(sprintf("#%s-%s-panel", active_ns, component))) ||
+            !is.null(self$get_html(sprintf("#%s-%s-table", active_ns, component)))) {
+          private$ns[[component]] <- sprintf("%s-%s", active_ns, component)
+        } else {
+          private$ns[[component]] <- sprintf("%s-module_%s", active_ns, component)
+        }
       }
     },
     # @description

--- a/man/TealAppDriver.Rd
+++ b/man/TealAppDriver.Rd
@@ -31,12 +31,15 @@ driving a teal application for performing interactions for \code{shinytest2} tes
 \item \href{#method-TealAppDriver-active_module_element}{\code{TealAppDriver$active_module_element()}}
 \item \href{#method-TealAppDriver-active_module_element_text}{\code{TealAppDriver$active_module_element_text()}}
 \item \href{#method-TealAppDriver-active_filters_ns}{\code{TealAppDriver$active_filters_ns()}}
+\item \href{#method-TealAppDriver-active_data_summary_ns}{\code{TealAppDriver$active_data_summary_ns()}}
+\item \href{#method-TealAppDriver-active_data_summary_element}{\code{TealAppDriver$active_data_summary_element()}}
 \item \href{#method-TealAppDriver-get_active_module_input}{\code{TealAppDriver$get_active_module_input()}}
 \item \href{#method-TealAppDriver-get_active_module_output}{\code{TealAppDriver$get_active_module_output()}}
 \item \href{#method-TealAppDriver-get_active_module_table_output}{\code{TealAppDriver$get_active_module_table_output()}}
 \item \href{#method-TealAppDriver-get_active_module_plot_output}{\code{TealAppDriver$get_active_module_plot_output()}}
 \item \href{#method-TealAppDriver-set_active_module_input}{\code{TealAppDriver$set_active_module_input()}}
 \item \href{#method-TealAppDriver-get_active_filter_vars}{\code{TealAppDriver$get_active_filter_vars()}}
+\item \href{#method-TealAppDriver-get_active_data_summary_table}{\code{TealAppDriver$get_active_data_summary_table()}}
 \item \href{#method-TealAppDriver-is_visible}{\code{TealAppDriver$is_visible()}}
 \item \href{#method-TealAppDriver-get_active_data_filters}{\code{TealAppDriver$get_active_data_filters()}}
 \item \href{#method-TealAppDriver-add_filter_var}{\code{TealAppDriver$add_filter_var()}}
@@ -309,6 +312,39 @@ Get the active shiny name space for interacting with the filter panel.
 }
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TealAppDriver-active_data_summary_ns"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-active_data_summary_ns}{}}}
+\subsection{Method \code{active_data_summary_ns()}}{
+Get the active shiny name space for interacting with the data-summary panel.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$active_data_summary_ns()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+(\code{string}) The active shiny name space of the data-summary component.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TealAppDriver-active_data_summary_element"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-active_data_summary_element}{}}}
+\subsection{Method \code{active_data_summary_element()}}{
+Get the active shiny name space bound with a custom \code{element} name.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$active_data_summary_element(element)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{element}}{\code{character(1)} custom element name.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+(\code{string}) The active shiny name space of the component bound with the input \code{element}.
+}
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TealAppDriver-get_active_module_input"></a>}}
 \if{latex}{\out{\hypertarget{method-TealAppDriver-get_active_module_input}{}}}
 \subsection{Method \code{get_active_module_input()}}{
@@ -429,6 +465,19 @@ Get the active datasets that can be accessed via the filter panel of the current
 \if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_filter_vars()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TealAppDriver-get_active_data_summary_table"></a>}}
+\if{latex}{\out{\hypertarget{method-TealAppDriver-get_active_data_summary_table}{}}}
+\subsection{Method \code{get_active_data_summary_table()}}{
+Get the active data summary table
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TealAppDriver$get_active_data_summary_table()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+\code{data.frame}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TealAppDriver-is_visible"></a>}}

--- a/tests/testthat/test-module_data_summary.R
+++ b/tests/testthat/test-module_data_summary.R
@@ -1,0 +1,165 @@
+output_table <- function(output) {
+  as.data.frame(rvest::html_table(rvest::read_html(output$table$html))[[1]])
+}
+
+testthat::test_that("srv_data_summary calculates filter_overview properly for a single dataset ", {
+  data <- teal.data::teal_data(iris_raw = iris, iris = iris[1:50, ])
+  teal.data::datanames(data) <- 'iris'
+
+    shiny::testServer(
+      app = srv_data_summary,
+      args = list(
+        id = "test",
+        teal_data = reactive(data)
+      ),
+      expr = {
+        testthat::expect_equal(
+          get_filter_overview(teal_data),
+          data.frame(
+            dataname = 'iris',
+            obs = 150,
+            obs_filtered = 50,
+            subjects = NA,
+            subjects_filtered = NA
+          )
+        )
+      }
+   )
+})
+
+testthat::test_that("srv_data_summary does not produce subjects column if there is no join keys", {
+  data <- teal.data::teal_data(iris_raw = iris, iris = iris[1:50, ])
+  teal.data::datanames(data) <- 'iris'
+
+  shiny::testServer(
+    app = srv_data_summary,
+    args = list(
+      id = "test",
+      teal_data = reactive(data)
+    ),
+    expr = {
+      testthat::expect_equal(
+        output_table(output),
+        data.frame(
+          X1 = c('Data Name', 'iris'),
+          X2 = c('Obs', '50/150')
+        )
+      )
+    }
+  )
+})
+
+testthat::test_that("srv_data_summary produces subjects column if there are join keys", {
+  data <- teal.data::teal_data(
+    mtcars1 = mtcars[1:30,],
+    mtcars1_raw = mtcars,
+    mtcars2 = data.frame(am = c(0,1), test = c('a', 'b')),
+    mtcars2_raw = data.frame(am = c(0,1), test = c('a', 'b'))
+  )
+  teal.data::datanames(data) <- c('mtcars1', 'mtcars2')
+
+  teal.data::join_keys(data) <- teal.data::join_keys(
+    teal.data::join_key('mtcars2', 'mtcars1', keys = c('am'))
+  )
+
+  shiny::testServer(
+    app = srv_data_summary,
+    args = list(
+      id = "test",
+      teal_data = reactive(data)
+    ),
+    expr = {
+      testthat::expect_equal(
+        output_table(output),
+        data.frame(
+          X1 = c('Data Name', 'mtcars1', 'mtcars2'),
+          X2 = c('Obs', '30/32', '2/2'),
+          X3 = c('Subjects', '2/2', '2/2')
+        )
+      )
+    }
+  )
+})
+
+testthat::test_that("srv_data_summary filter_overview returns NULL for empty datanames", {
+  data <- teal.data::teal_data(iris_raw = iris, iris = iris[1:50, ])
+  teal.data::datanames(data) <- character(0)
+
+  shiny::testServer(
+    app = srv_data_summary,
+    args = list(
+      id = "test",
+      teal_data = reactive(data)
+    ),
+    expr = {
+      testthat::expect_null(
+        get_filter_overview(teal_data)
+      )
+    }
+  )
+})
+
+testthat::test_that("srv_data_summary crashes if there is data, but not filtered_data (raw)", {
+  data <- teal.data::teal_data(iris = iris)
+
+  testthat::expect_error(
+    shiny::testServer(
+      app = srv_data_summary,
+      args = list(
+        id = "test",
+        teal_data = reactive(data)
+      ),
+      expr = output$table
+    ),
+    'arguments imply differing number of rows'
+  )
+})
+
+
+testthat::test_that("srv_data_summary calculates counts properly for mixture of MAE dataset, dataframes and vectors", {
+  testthat::skip_if_not_installed("MultiAssayExperiment")
+  data <- teal.data::teal_data() %>%
+    within(
+      {
+        mtcars1 <- mtcars[1:30, ]
+        mtcars1_raw <- mtcars
+        mtcars2 <- data.frame(am = c(0,1), test = c('a', 'b'))
+        mtcars2_raw <- data.frame(am = c(0,1), test = c('a', 'b'))
+        iris <- iris[1:50, ]
+        iris_raw <- iris
+        library(MultiAssayExperiment)
+        data("miniACC", package = "MultiAssayExperiment", envir = environment())
+        miniACC_raw <- miniACC
+        CO2_raw <- CO2 <- CO2
+        factors_raw <- factors <- names(Filter(isTRUE, vapply(CO2, is.factor, logical(1L))))
+        CO2[factors] <- lapply(CO2[factors], as.character)
+      }
+    )
+
+  teal.data::join_keys(data) <- teal.data::join_keys(
+    teal.data::join_key('mtcars2', 'mtcars1', keys = c('am'))
+  )
+
+  teal.data::datanames(data) <- c('mtcars1', 'mtcars2', 'iris', 'miniACC', 'CO2', 'factors')
+
+  shiny::testServer(
+    app = srv_data_summary,
+    args = list(
+      id = "test",
+      teal_data = reactive(data)
+    ),
+    expr = {
+      testthat::expect_equal(
+        output_table(output),
+        data.frame(
+          X1 = c(
+            "Data Name", "mtcars1", "mtcars2", "iris", "miniACC", "- RNASeq2GeneNorm", "- gistict", "- RPPAArray",
+            "- Mutations", "- miRNASeqGene", "CO2", "factors"
+          ),
+          X2 = c("Obs", "30/32", "2/2", "50/50", "", "198/198", "198/198", "33/33", "97/97", "471/471", "84/84", ""),
+          X3 = c("Subjects", "2/2", "2/2", "", "92/92", "79/79", "90/90", "46/46", "90/90", "80/80", "", "")
+        )
+      )
+    }
+  )
+})

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -123,7 +123,7 @@ testthat::test_that("srv_teal: data_rv is NULL when data reactive returns qenv.e
     app = srv_teal,
     args = list(
       id = "test",
-      data = reactive(teal.data::teal_data() |> within(stop("Error"))),
+      data = reactive(teal.data::teal_data() %>% within(stop("Error"))),
       modules = modules(example_module())
     ),
     expr = {

--- a/tests/testthat/test-shinytest2-data_summary.R
+++ b/tests/testthat/test-shinytest2-data_summary.R
@@ -1,0 +1,108 @@
+testthat::test_that("e2e: data summary list only data names if there is no MAE or data.frames in teal_data", {
+  skip_if_too_deep(5)
+  app <- TealAppDriver$new(
+    data = teal.data::teal_data(x = 1),
+    modules = example_module()
+  )
+
+  testthat::expect_identical(
+    as.data.frame(app$get_active_data_summary_table()),
+    data.frame(
+      `Data Name` = c('x'),
+      check.names = FALSE
+    )
+  )
+
+  app$stop()
+})
+
+
+testthat::test_that("e2e: data summary is displayed with 2 columns data without keys", {
+  skip_if_too_deep(5)
+  app <- TealAppDriver$new(
+    data = simple_teal_data(), # iris, mtcars
+    modules = example_module()
+  )
+
+  testthat::expect_identical(
+    as.data.frame(app$get_active_data_summary_table()),
+    data.frame(
+      `Data Name` = c('iris', 'mtcars'),
+      Obs = c('150/150', '32/32'),
+      check.names = FALSE
+    )
+  )
+
+  app$stop()
+})
+
+testthat::test_that("e2e: data summary is displayed with 3 columns for data with join keys", {
+  skip_if_too_deep(5)
+
+  data <- teal.data::teal_data(mtcars1 = mtcars, mtcars2 = mtcars)
+
+  teal.data::join_keys(data) <- teal.data::join_keys(
+    teal.data::join_key('mtcars1', 'mtcars2', keys = c('am', 'gear'))
+  )
+
+  app <- TealAppDriver$new(
+    data = data,
+    modules = example_module()
+  )
+
+  testthat::expect_identical(
+    as.data.frame(app$get_active_data_summary_table()),
+    data.frame(
+      `Data Name` = c('mtcars1', 'mtcars2'),
+      Obs = c('32/32', '330/320'),
+      Subjects = c('4/4', '4/4'),
+      check.names = FALSE
+    )
+  )
+
+  app$stop()
+})
+
+testthat::test_that(
+  "e2e: data summary is displayed properly if teal_data include data.frames with join keys, MAE objects and vectors", {
+    testthat::skip_if_not_installed("MultiAssayExperiment")
+    skip_if_too_deep(5)
+
+    data <- teal.data::teal_data() |>
+      within(
+        {
+          mtcars1 <- mtcars
+          mtcars2 <- mtcars
+          iris <- iris
+          library(MultiAssayExperiment)
+          data("miniACC", package = "MultiAssayExperiment", envir = environment())
+          CO2 <- CO2
+          factors <- names(Filter(isTRUE, vapply(CO2, is.factor, logical(1L))))
+          CO2[factors] <- lapply(CO2[factors], as.character)
+        }
+      )
+
+    teal.data::join_keys(data) <- teal.data::join_keys(
+      teal.data::join_key('mtcars1', 'mtcars2', keys = c('am', 'gear'))
+    )
+
+    app <- TealAppDriver$new(
+      data = data,
+      modules = example_module()
+    )
+
+    testthat::expect_identical(
+      as.data.frame(app$get_active_data_summary_table()),
+      data.frame(
+        `Data Name` = c(
+          "CO2", "iris", "miniACC", "- RNASeq2GeneNorm", "- gistict", "- RPPAArray", "- Mutations", "- miRNASeqGene",
+          "mtcars1", "mtcars2", "factors"
+        ),
+        Obs = c("84/84", "150/150", "", "198/198", "198/198", "33/33", "97/97", "471/471", "32/32", "330/32", ""),
+        Subjects = c("", "", "92/92", "79/79", "90/90", "46/46", "90/90", "80/80", "4/4", "4/4", ""),
+        check.names = FALSE
+      )
+    )
+
+  app$stop()
+})

--- a/tests/testthat/test-shinytest2-data_summary.R
+++ b/tests/testthat/test-shinytest2-data_summary.R
@@ -39,10 +39,10 @@ testthat::test_that("e2e: data summary is displayed with 2 columns data without 
 testthat::test_that("e2e: data summary is displayed with 3 columns for data with join keys", {
   skip_if_too_deep(5)
 
-  data <- teal.data::teal_data(mtcars1 = mtcars, mtcars2 = mtcars)
+  data <- teal.data::teal_data(mtcars1 = mtcars, mtcars2 = data.frame(am = c(0,1), test = c('a', 'b')))
 
   teal.data::join_keys(data) <- teal.data::join_keys(
-    teal.data::join_key('mtcars1', 'mtcars2', keys = c('am', 'gear'))
+    teal.data::join_key('mtcars2', 'mtcars1', keys = c('am'))
   )
 
   app <- TealAppDriver$new(
@@ -54,8 +54,8 @@ testthat::test_that("e2e: data summary is displayed with 3 columns for data with
     as.data.frame(app$get_active_data_summary_table()),
     data.frame(
       `Data Name` = c('mtcars1', 'mtcars2'),
-      Obs = c('32/32', '330/320'),
-      Subjects = c('4/4', '4/4'),
+      Obs = c('32/32', '2/2'),
+      Subjects = c('2/2', '2/2'),
       check.names = FALSE
     )
   )
@@ -72,7 +72,7 @@ testthat::test_that(
       within(
         {
           mtcars1 <- mtcars
-          mtcars2 <- mtcars
+          mtcars2 = data.frame(am = c(0,1), test = c('a', 'b'))
           iris <- iris
           library(MultiAssayExperiment)
           data("miniACC", package = "MultiAssayExperiment", envir = environment())
@@ -83,7 +83,7 @@ testthat::test_that(
       )
 
     teal.data::join_keys(data) <- teal.data::join_keys(
-      teal.data::join_key('mtcars1', 'mtcars2', keys = c('am', 'gear'))
+      teal.data::join_key('mtcars2', 'mtcars1', keys = c('am'))
     )
 
     app <- TealAppDriver$new(
@@ -98,8 +98,8 @@ testthat::test_that(
           "CO2", "iris", "miniACC", "- RNASeq2GeneNorm", "- gistict", "- RPPAArray", "- Mutations", "- miRNASeqGene",
           "mtcars1", "mtcars2", "factors"
         ),
-        Obs = c("84/84", "150/150", "", "198/198", "198/198", "33/33", "97/97", "471/471", "32/32", "330/32", ""),
-        Subjects = c("", "", "92/92", "79/79", "90/90", "46/46", "90/90", "80/80", "4/4", "4/4", ""),
+        Obs = c("84/84", "150/150", "", "198/198", "198/198", "33/33", "97/97", "471/471", "32/32", "2/2", ""),
+        Subjects = c("", "", "92/92", "79/79", "90/90", "46/46", "90/90", "80/80", "2/2", "2/2", ""),
         check.names = FALSE
       )
     )

--- a/tests/testthat/test-shinytest2-data_summary.R
+++ b/tests/testthat/test-shinytest2-data_summary.R
@@ -68,7 +68,7 @@ testthat::test_that(
     testthat::skip_if_not_installed("MultiAssayExperiment")
     skip_if_too_deep(5)
 
-    data <- teal.data::teal_data() |>
+    data <- teal.data::teal_data() %>%
       within(
         {
           mtcars1 <- mtcars


### PR DESCRIPTION
A couple of tests for `data_summary` panel. Knowing that namespace can get changed based on the final decision of the UI/UX placement of the new `data_summary` panel we need to be aware that those methods and tests might need to be updated. Currently trying to provide some more testing for the panel