### PR TITLE
Fix +/- add new filter buttons when changing data using teal_data_module

### DIFF
--- a/R/1.0_filter_panel.R
+++ b/R/1.0_filter_panel.R
@@ -28,16 +28,18 @@ ui_filter_panel <- function(id) {
 srv_filter_panel <- function(id, datasets, active_datanames, data_rv, is_active) {
   checkmate::assert_class(datasets, "reactive")
   moduleServer(id, function(input, output, session) {
+    index <- reactiveVal(1L)
     output$panel <- renderUI({
       req(inherits(datasets(), "FilteredData"))
       isolate({
         # render will be triggered only when FilteredData object changes (not when filters change)
         # technically it means that teal_data_module needs to be refreshed
         logger::log_debug("srv_filter_panel rendering filter panel.")
+        index(index() + 1L)
         filtered_data <- datasets()
-        filtered_data$srv_active("filters", active_datanames = active_datanames)
         # todo: make sure to bump the `teal.slice` version. Please use the branch `669_insertUI@main` in `teal.slice`.
-        filtered_data$ui_active(session$ns("filters"), active_datanames = active_datanames)
+        filtered_data$srv_active(sprintf("filters_%s", index()), active_datanames = active_datanames)
+        filtered_data$ui_active(session$ns(sprintf("filters_%s", index())), active_datanames = active_datanames)
       })
     })
 


### PR DESCRIPTION
Fixes the +/- icon behavior on the filter panel.
Please checkout to the `fix-add-remove-ui@669_insertUI@main` in both `teal` and `teal.slice`
In `teal.slice` it just reverts one commit to the working version of the show/hide logic.

When the data changes using `teal_data_module` the filter panel observers are being called once again thus running the scope of the observers as many times the data changes.
The fix is to reinitialize the filter panel with new NS so the observers are not connected to the active UI anymore.

### Example app to test
```r
pkgload::load_all("teal.slice")
pkgload::load_all("teal")
library(MultiAssayExperiment)

data <- teal::teal_data_module(
  ui = function(id) {
    ns <- shiny::NS(id)
    shiny::tagList(
      shiny::textInput(ns("username"), label = "Username"),
      shiny::passwordInput(ns("password"), label = "Password"),
      shiny::actionButton(ns("submit"), label = "Submit")
    )
  },
  server = function(id, ...) {
    shiny::moduleServer(id, function(input, output, session) {
      shiny::eventReactive(input$submit, {
        data <- teal.data::teal_data() |>
          within(
            {
              logger::log_debug("Loading data...")
              iris <- iris
              data("miniACC", package = "MultiAssayExperiment", envir = environment())
            },
            username = input$username,
            password = input$password
          )
        data
      })
    })
  },
  once = FALSE
)

app <- init(
  data = data,
  modules = example_module()
)

shiny::runApp(app$ui, app$server)
```