### PR TITLE
Adds tests to check the new features of teal_data_module

### DIFF
--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -1072,7 +1072,7 @@ testthat::describe("srv_teal filters", {
           filter = teal_slices(module_specific = TRUE)
         ),
         expr = {
-          testthat::skip("need a fix in a .slicesGlobal")
+          # testthat::skip("need a fix in a .slicesGlobal")
           session$setInputs(`teal_modules-active_tab` = "module_1")
           session$setInputs(`teal_modules-active_tab` = "module_2")
           slices_global$slices_set(teal_slices(

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -1072,7 +1072,7 @@ testthat::describe("srv_teal filters", {
           filter = teal_slices(module_specific = TRUE)
         ),
         expr = {
-          # testthat::skip("need a fix in a .slicesGlobal")
+          testthat::skip("need a fix in a .slicesGlobal")
           session$setInputs(`teal_modules-active_tab` = "module_1")
           session$setInputs(`teal_modules-active_tab` = "module_2")
           slices_global$slices_set(teal_slices(

--- a/tests/testthat/test-shinytest2-data_summary.R
+++ b/tests/testthat/test-shinytest2-data_summary.R
@@ -107,6 +107,8 @@ testthat::test_that(
       }
     )
 
+    datanames(data) <- c("mtcars1", "mtcars2", "iris", "miniACC", "CO2")
+
     teal.data::join_keys(data) <- teal.data::join_keys(
       teal.data::join_key("mtcars2", "mtcars1", keys = c("am"))
     )

--- a/tests/testthat/test-shinytest2-data_summary.R
+++ b/tests/testthat/test-shinytest2-data_summary.R
@@ -107,7 +107,7 @@ testthat::test_that(
       }
     )
 
-    datanames(data) <- c("mtcars1", "mtcars2", "iris", "miniACC", "CO2")
+    datanames(data) <- c("mtcars1", "mtcars2", "iris", "miniACC", "CO2", "factors")
 
     teal.data::join_keys(data) <- teal.data::join_keys(
       teal.data::join_key("mtcars2", "mtcars1", keys = c("am"))

--- a/tests/testthat/test-shinytest2-teal_data_module.R
+++ b/tests/testthat/test-shinytest2-teal_data_module.R
@@ -157,10 +157,15 @@ testthat::test_that("e2e: teal_data_module gets removed after successful data lo
     modules = example_module(label = "Example Module")
   )
 
-  app$click("teal-data-teal_data_module-data-submit")
+  submit <- "teal-data-teal_data_module-data-submit"
+  app$click(submit)
 
   testthat::expect_false(
     app$is_visible('#teal-teal_modules-active_tab a[data-value="teal_data_module"]')
+  )
+
+  testthat::expect_false(
+    app$is_visible(sprintf("#%s", submit))
   )
 
   app$stop()
@@ -242,7 +247,7 @@ testthat::test_that("e2e: teal_data_module will make other tabs inactive before 
 
   testthat::expect_equal(
     app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a[data-value*='example_module']")
+      rvest::html_nodes("a[data-value*='example_module']") |>
       rvest::html_attr("disabled"),
     c("disabled", "disabled")
   )
@@ -251,7 +256,7 @@ testthat::test_that("e2e: teal_data_module will make other tabs inactive before 
 
   testthat::expect_true(
     app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a[data-value*='example_module']")
+      rvest::html_nodes("a[data-value*='example_module']") |>
       rvest::html_attr("disabled") |>
       unique() |>
       is.na()

--- a/tests/testthat/test-shinytest2-teal_data_module.R
+++ b/tests/testthat/test-shinytest2-teal_data_module.R
@@ -159,12 +159,10 @@ testthat::test_that("e2e: teal_data_module gets removed after successful data lo
 
   app$click("teal-data-teal_data_module-data-submit")
 
-  testthat::expect_equal(
-    app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a[data-value='teal_data_module']") |>
-      rvest::html_attr("style"),
-    "display: none;"
+  testthat::expect_false(
+    app$is_visible('#teal-teal_modules-active_tab a[data-value="teal_data_module"]')
   )
+
   app$stop()
 })
 
@@ -202,10 +200,7 @@ testthat::test_that("e2e: teal_data_module is still visible after successful dat
   app$click("teal-data-teal_data_module-data-submit")
 
   testthat::expect_true(
-    app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a[data-value='teal_data_module']") |>
-      rvest::html_attr("style") |>
-      is.na()
+    app$is_visible('#teal-teal_modules-active_tab a[data-value="teal_data_module"]')
   )
 
   app$stop()

--- a/tests/testthat/test-shinytest2-teal_data_module.R
+++ b/tests/testthat/test-shinytest2-teal_data_module.R
@@ -256,7 +256,7 @@ testthat::test_that("e2e: teal_data_module will make other tabs inactive before 
 
   testthat::expect_true(
     app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a:not([data-value='teal_data_module'])") |>
+      rvest::html_nodes("a[data-value*='example_module']")
       rvest::html_attr("disabled") |>
       unique() |>
       is.na()

--- a/tests/testthat/test-shinytest2-teal_data_module.R
+++ b/tests/testthat/test-shinytest2-teal_data_module.R
@@ -246,20 +246,30 @@ testthat::test_that("e2e: teal_data_module will make other tabs inactive before 
   )
 
   testthat::expect_equal(
-    app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a[data-value*='example_module']") |>
-      rvest::html_attr("disabled"),
+    rvest::html_attr(
+      rvest::html_nodes(
+        app$get_html_rvest("#teal-teal_modules-active_tab"),
+        "a[data-value*='example_module']"
+      ),
+      "disabled"
+    ),
     c("disabled", "disabled")
   )
 
   app$click("teal-data-teal_data_module-data-submit")
 
   testthat::expect_true(
-    app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a[data-value*='example_module']") |>
-      rvest::html_attr("disabled") |>
-      unique() |>
-      is.na()
+    is.na(
+      unique(
+        rvest::html_attr(
+          rvest::html_nodes(
+            app$get_html_rvest("#teal-teal_modules-active_tab"),
+            "a[data-value*='example_module']"
+          ),
+          "disabled"
+        )
+      )
+    )
   )
 
   app$stop()

--- a/tests/testthat/test-shinytest2-teal_data_module.R
+++ b/tests/testthat/test-shinytest2-teal_data_module.R
@@ -247,7 +247,7 @@ testthat::test_that("e2e: teal_data_module will make other tabs inactive before 
 
   testthat::expect_equal(
     app$get_html_rvest("#teal-teal_modules-active_tab") |>
-      rvest::html_nodes("a:not([data-value='teal_data_module'])") |>
+      rvest::html_nodes("a[data-value*='example_module']")
       rvest::html_attr("disabled"),
     c("disabled", "disabled")
   )


### PR DESCRIPTION
Added tests to check the two new features of the `teal_data_module`:

1. Now `teal_data_module` can have `once` argument.
2. The module tabs are disabled when `teal_data_module` is not loaded.