### PR TITLE
Removes string colors style from error messages in `ui/srv_validate_reactive_teal_data`

### DIFF
--- a/R/module_data_summary.R
+++ b/R/module_data_summary.R
@@ -89,7 +89,7 @@ srv_data_summary <- function(id, teal_data) {
       output$table <- renderUI({
         summary_table_out <- try(summary_table())
         if (inherits(summary_table_out, "try-error")) {
-          stop(strip_style(conditionMessage(attr(summary_table_out, "condition"))))
+          stop("Data and/or filters have an error. See details on the main panel.")
         } else {
           body_html <- apply(
             summary_table_out,

--- a/R/module_data_summary.R
+++ b/R/module_data_summary.R
@@ -87,39 +87,44 @@ srv_data_summary <- function(id, teal_data) {
       })
 
       output$table <- renderUI({
-        body_html <- apply(
-          summary_table(),
-          1,
-          function(x) {
-            tags$tr(
-              tagList(
-                tags$td(
-                  if (all(x[-1] == "")) {
-                    icon(
-                      name = "fas fa-exclamation-triangle",
-                      title = "Unsupported dataset",
-                      `data-container` = "body",
-                      `data-toggle` = "popover",
-                      `data-content` = "object not supported by the data_summary module"
-                    )
-                  },
-                  x[1]
-                ),
-                lapply(x[-1], tags$td)
+        summary_table_out <- try(summary_table())
+        if (inherits(summary_table_out, "try-error")) {
+          stop(strip_style(conditionMessage(attr(summary_table_out, "condition"))))
+        } else {
+          body_html <- apply(
+            summary_table_out,
+            1,
+            function(x) {
+              tags$tr(
+                tagList(
+                  tags$td(
+                    if (all(x[-1] == "")) {
+                      icon(
+                        name = "fas fa-exclamation-triangle",
+                        title = "Unsupported dataset",
+                        `data-container` = "body",
+                        `data-toggle` = "popover",
+                        `data-content` = "object not supported by the data_summary module"
+                      )
+                    },
+                    x[1]
+                  ),
+                  lapply(x[-1], tags$td)
+                )
               )
-            )
-          }
-        )
+            }
+          )
 
-        header_labels <- names(summary_table())
-        header_html <- tags$tr(tagList(lapply(header_labels, tags$td)))
+          header_labels <- names(summary_table())
+          header_html <- tags$tr(tagList(lapply(header_labels, tags$td)))
 
-        table_html <- tags$table(
-          class = "table custom-table",
-          tags$thead(header_html),
-          tags$tbody(body_html)
-        )
-        table_html
+          table_html <- tags$table(
+            class = "table custom-table",
+            tags$thead(header_html),
+            tags$tbody(body_html)
+          )
+          table_html
+        }
       })
 
       summary_table # testing purpose

--- a/R/module_data_summary.R
+++ b/R/module_data_summary.R
@@ -89,7 +89,7 @@ srv_data_summary <- function(id, teal_data) {
       output$table <- renderUI({
         summary_table_out <- try(summary_table())
         if (inherits(summary_table_out, "try-error")) {
-          stop("Data and/or filters have an error. See details on the main panel.")
+          stop("Error occurred during data processing. See details in the main panel.")
         } else {
           body_html <- apply(
             summary_table_out,

--- a/R/module_teal_data.R
+++ b/R/module_teal_data.R
@@ -116,7 +116,7 @@ srv_validate_reactive_teal_data <- function(id, # nolint: object_length
             need(
               FALSE,
               paste(
-                data_out$message,
+                strip_style(data_out$message),
                 "Check your inputs or contact app developer if error persists.",
                 sep = ifelse(identical(data_out$message, ""), "", "\n")
               )
@@ -132,7 +132,7 @@ srv_validate_reactive_teal_data <- function(id, # nolint: object_length
             FALSE,
             paste(
               "Error when executing `teal_data_module` passed to `data`:\n ",
-              paste(data_out$message, collapse = "\n"),
+              strip_style(paste(data_out$message, collapse = "\n")),
               "\n Check your inputs or contact app developer if error persists."
             )
           )
@@ -144,7 +144,7 @@ srv_validate_reactive_teal_data <- function(id, # nolint: object_length
           inherits(data_out, "teal_data"),
           paste(
             "Error: `teal_data_module` passed to `data` failed to return `teal_data` object, returned",
-            toString(sQuote(class(data_out))),
+            strip_style(toString(sQuote(class(data_out)))),
             "instead.",
             "\n Check your inputs or contact app developer if error persists."
           )

--- a/R/utils.R
+++ b/R/utils.R
@@ -299,7 +299,7 @@ get_unique_labels <- function(labels) {
   make.unique(gsub("[^[:alnum:]]", "_", tolower(labels)), sep = "_")
 }
 
-#' Function imported from `crayon` package
+#' Function with regular expression imported from `crayon` package
 #' @noRd
 strip_style <- function(string) {
   checkmate::assert_string(string)

--- a/R/utils.R
+++ b/R/utils.R
@@ -299,7 +299,7 @@ get_unique_labels <- function(labels) {
   make.unique(gsub("[^[:alnum:]]", "_", tolower(labels)), sep = "_")
 }
 
-#' Function with regular expression imported from `crayon` package
+#' Remove ANSI escape sequences from a string
 #' @noRd
 strip_style <- function(string) {
   checkmate::assert_string(string)

--- a/R/utils.R
+++ b/R/utils.R
@@ -298,3 +298,17 @@ defunction <- function(x) {
 get_unique_labels <- function(labels) {
   make.unique(gsub("[^[:alnum:]]", "_", tolower(labels)), sep = "_")
 }
+
+#' Function imported from `crayon` package
+#' @noRd
+strip_style <- function(string) {
+  checkmate::assert_string(string)
+
+  gsub(
+    "(?:(?:\\x{001b}\\[)|\\x{009b})(?:(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?[A-M|f-m])|\\x{001b}[A-M]",
+    "",
+    string,
+    perl = TRUE,
+    useBytes = TRUE
+  )
+}


### PR DESCRIPTION
Part of #1253

Additionally, we could have a static message on the summary, instead of repeating it.

### Before vs. With this PR

![image](https://github.com/user-attachments/assets/1d4e52ec-e9a4-4dcd-8e1d-012ac9aed6df)

#### With simple error (not in PR yet)

Simple change with

```diff
diff --git a/R/module_data_summary.R b/R/module_data_summary.R
index 76947d58a..dadfff0dc 100644
--- a/R/module_data_summary.R
+++ b/R/module_data_summary.R
@@ -89,7 +89,7 @@ srv_data_summary <- function(id, teal_data) {
       output$table <- renderUI({
         summary_table_out <- try(summary_table())
         if (inherits(summary_table_out, "try-error")) {
-          stop(strip_style(conditionMessage(attr(summary_table_out, "condition"))))
+          stop("Data and/or filters have an error. See details on main panel.")
         } else {
           body_html <- apply(
             summary_table_out,
```

![image](https://github.com/user-attachments/assets/f91f4fa3-78af-413f-a940-8080f876766a)
