### PR TITLE
Always position the teal util icons in the same place

### DIFF
--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -108,7 +108,7 @@ ui_teal <- function(id,
     ),
     tags$div(
       id = ns("options_buttons"),
-      style = "margin-left: auto;",
+      style = "position: absolute; right: 10px;",
       bookmark_panel_ui,
       tags$button(
         class = "btn action-button filter_hamburger", # see sidebar.css for style filter_hamburger

--- a/inst/css/custom.css
+++ b/inst/css/custom.css
@@ -52,6 +52,7 @@
 .nav {
   display: flex;
   flex-wrap: wrap;
+  width: calc(100% - 160px);
 }
 
 header {
@@ -66,7 +67,7 @@ footer {
 }
 
 #teal_secondary_col .well {
-  margin: 0  0 15px 0;
+  margin: 0 0 15px 0;
 }
 
 #shiny-modal:has(> .modal-dialog > .modal-content > #landingpopup) {


### PR DESCRIPTION
Have a fixed position for the icons in the top right which do not change place when the number of teal tab grows.

#### Before
<img width="544" alt="Screenshot 2024-08-07 at 7 10 13 PM" src="https://github.com/user-attachments/assets/0187ee9a-d808-41f1-94dd-9cc9ef2f4434">


#### After the changes in the PR
<img width="546" alt="Screenshot 2024-08-07 at 7 09 45 PM" src="https://github.com/user-attachments/assets/28cd761f-2e68-4a67-b162-e912cc316379">
