### PR TITLE
vbump deps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,8 @@ BugReports: https://github.com/insightsengineering/teal/issues
 Depends:
     R (>= 4.0),
     shiny (>= 1.8.1),
-    teal.data (>= 0.5.0),
-    teal.slice (>= 0.5.0)
+    teal.data (> 0.6.0.9007),
+    teal.slice (>= 0.5.1.9009)
 Imports:
     checkmate (>= 2.1.0),
     future (>= 1.33.2),


### PR DESCRIPTION
follow-up after #1253

tests are failing using the released version