### PR TITLE
Set @datanames in teal if unspecified

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -214,13 +214,13 @@ init <- function(data,
       stop("The environment of `data` is empty.")
     }
 
-    if (length(teal.data::datanames(data)) == 0) {
+    if (!length(teal.data::datanames(data))) {
       warning("`data` object has no datanames. Default datanames are set using `teal_data`'s environment.")
       teal.data::datanames(data) <- .teal_data_ls(data)
     }
 
     is_modules_ok <- check_modules_datanames(modules, teal.data::datanames(data))
-    if (!isTRUE(is_modules_ok) && length(unlist(extract_transformers(modules))) == 0) {
+    if (!isTRUE(is_modules_ok) && !length(unlist(extract_transformers(modules)))) {
       lapply(is_modules_ok$string, warning, call. = FALSE)
     }
 

--- a/R/init.R
+++ b/R/init.R
@@ -210,20 +210,21 @@ init <- function(data,
 
   ## `data` - `modules`
   if (inherits(data, "teal_data")) {
-    if (length(.teal_data_datanames(data)) == 0) {
+    if (!length(.teal_data_ls(data))) {
       stop("The environment of `data` is empty.")
     }
 
-    if (!length(teal.data::datanames(data))) {
+    if (length(teal.data::datanames(data)) == 0) {
       warning("`data` object has no datanames. Default datanames are set using `teal_data`'s environment.")
+      teal.data::datanames(data) <- .teal_data_ls(data)
     }
 
-    is_modules_ok <- check_modules_datanames(modules, .teal_data_datanames(data))
+    is_modules_ok <- check_modules_datanames(modules, teal.data::datanames(data))
     if (!isTRUE(is_modules_ok) && length(unlist(extract_transformers(modules))) == 0) {
       lapply(is_modules_ok$string, warning, call. = FALSE)
     }
 
-    is_filter_ok <- check_filter_datanames(filter, .teal_data_datanames(data))
+    is_filter_ok <- check_filter_datanames(filter, teal.data::datanames(data))
     if (!isTRUE(is_filter_ok)) {
       warning(is_filter_ok)
       # we allow app to continue if applied filters are outside

--- a/R/module_init_data.R
+++ b/R/module_init_data.R
@@ -107,7 +107,7 @@ srv_init_data <- function(id, data, modules, filter = teal_slices()) {
         )
       }
 
-      is_filter_ok <- check_filter_datanames(filter, .teal_data_datanames(data_validated()))
+      is_filter_ok <- check_filter_datanames(filter, teal.data::datanames(data_validated()))
       if (!isTRUE(is_filter_ok)) {
         showNotification(
           "Some filters were not applied because of incompatibility with data. Contact app developer.",
@@ -134,7 +134,10 @@ srv_init_data <- function(id, data, modules, filter = teal_slices()) {
     })
 
     # Adds signature protection to the datanames in the data
-    reactive(.add_signature_to_data(data_validated()))
+    reactive({
+      req(data_validated())
+      .add_signature_to_data(data_validated())
+    })
   })
 }
 
@@ -167,12 +170,12 @@ srv_init_data <- function(id, data, modules, filter = teal_slices()) {
 #' Get code that tests the integrity of the reproducible data
 #'
 #' @param data (`teal_data`) object holding the data
-#' @param datanames (`character`) names of `datasets`
 #'
 #' @return A character vector with the code lines.
 #' @keywords internal
 #'
-.get_hashes_code <- function(data, datanames = .teal_data_datanames(data)) {
+.get_hashes_code <- function(data) {
+  datanames <- teal.data::datanames(data)
   vapply(
     datanames,
     function(dataname, datasets) {

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -317,7 +317,7 @@ srv_teal_module.teal_module <- function(id,
         modules$transformers,
         function(t) {
           if (identical(attr(t, "datanames"), "all")) {
-            .teal_data_datanames(data)
+            teal.data::datanames(data)
           } else {
             intersect(
               include_parent_datanames(attr(t, "datanames"), teal.data::join_keys(data)),
@@ -334,7 +334,7 @@ srv_teal_module.teal_module <- function(id,
   checkmate::assert_class(data, "teal_data")
   checkmate::assert_class(modules, "teal_module")
   if (is.null(modules$datanames) || identical(modules$datanames, "all")) {
-    .teal_data_datanames(data)
+    teal.data::datanames(data)
   } else {
     intersect(
       include_parent_datanames(modules$datanames, teal.data::join_keys(data)),

--- a/R/module_teal_data.R
+++ b/R/module_teal_data.R
@@ -194,7 +194,6 @@ srv_validate_reactive_teal_data <- function(id, # nolint: object_length
   assert_reactive(this)
   assert_reactive(that)
   checkmate::assert_string(label)
-
   reactive({
     res <- try(this(), silent = TRUE)
     if (inherits(res, "teal_data")) {

--- a/R/teal_data_module.R
+++ b/R/teal_data_module.R
@@ -75,6 +75,13 @@ teal_data_module <- function(ui, server, label = "data module", once = TRUE) {
           pre = sprintf("From: 'teal_data_module()':\nA 'teal_data_module' with \"%s\" label:", label),
           post = "Please make sure that this module returns a 'reactive` object containing 'teal_data' class of object." # nolint: line_length_linter.
         )
+        reactive({
+          new_data <- data_out()
+          if (inherits(new_data, "teal_data") && !length(teal.data::datanames(new_data))) {
+            teal.data::datanames(new_data) <- .teal_data_ls(new_data)
+          }
+          new_data
+        })
       }
     ),
     label = label,

--- a/R/teal_data_utils.R
+++ b/R/teal_data_utils.R
@@ -70,17 +70,6 @@ NULL
 }
 
 #' @rdname teal_data_utilities
-.teal_data_datanames <- function(data) {
-  checkmate::assert_class(data, "teal_data")
-  datanames <- teal.data::datanames(data)
-  if (length(datanames)) {
-    datanames
-  } else {
-    .teal_data_ls(data)
-  }
-}
-
-#' @rdname teal_data_utilities
 .teal_data_ls <- function(data) {
   grep("._raw_", ls(teal.code::get_env(data), all.names = TRUE), value = TRUE, invert = TRUE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -65,7 +65,7 @@ include_parent_datanames <- function(dataname, join_keys) {
 #' @param datanames (`character`) vector of data set names to include; must be subset of `datanames(x)`
 #' @return A `FilteredData` object.
 #' @keywords internal
-teal_data_to_filtered_data <- function(x, datanames = .teal_data_datanames(x)) {
+teal_data_to_filtered_data <- function(x, datanames = teal.data::datanames(x)) {
   checkmate::assert_class(x, "teal_data")
   checkmate::assert_character(datanames, min.chars = 1L, any.missing = FALSE)
 


### PR DESCRIPTION
This simplifies a code in teal a little bit.
Instead of using `.teal_data_datanames` function which checks if `data@datanames` is specified and either get `data@datanames` or `ls(data@env)`,
here we set `data@datanames` if unspecified and always refer to `data@datanames`


What it changes is that in `teal_transform_module` when evaluated, `data` passed to its server, will always have `datanames` specified.