### PR TITLE
vbump teal.logger

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Imports:
     shinyjs,
     stats,
     teal.code (>= 0.5.0),
-    teal.logger (>= 0.1.3.9013),
+    teal.logger (>= 0.2.0),
     teal.reporter (>= 0.3.1.9004),
     teal.widgets (>= 0.4.0),
     utils


### PR DESCRIPTION
teal.logger had been already released so there is no point of depending on the old development version