### PR TITLE
`module()$datanames` : unify `combined_datanames` no matter what's the length of `transformers`

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -264,7 +264,7 @@ module <- function(label = "module",
   }
   checkmate::assert_list(transformers, types = "teal_transform_module")
   transformer_datanames <- unlist(lapply(transformers, attr, "datanames"))
-  combined_datanames <- if (identical(datanames, "all") || identical(transformer_datanames, "all")) {
+  combined_datanames <- if (identical(datanames, "all")) {
     "all"
   } else {
     union(datanames, transformer_datanames)

--- a/R/modules.R
+++ b/R/modules.R
@@ -264,7 +264,7 @@ module <- function(label = "module",
   }
   checkmate::assert_list(transformers, types = "teal_transform_module")
   transformer_datanames <- unlist(lapply(transformers, attr, "datanames"))
-  combined_datanames <- if (identical(datanames, "all")) {
+  combined_datanames <- if (identical(datanames, "all") || any(sapply(transformer_datanames, identical, "all"))) {
     "all"
   } else {
     union(datanames, transformer_datanames)

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -534,7 +534,7 @@ testthat::test_that("module datanames is appended by its transformers datanames"
   testthat::expect_identical(out$datanames, c("c", "a", "b"))
 })
 
-testthat::test_that("module datanames is set to union(datanames, 'all') if transformer $datanames is 'all'", {
+testthat::test_that("module datanames is set to 'all' if any transformer $datanames is 'all'", {
   transformer_w_datanames <- teal_transform_module(
     ui = function(id) NULL,
     server = function(id, data) {

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -534,7 +534,7 @@ testthat::test_that("module datanames is appended by its transformers datanames"
   testthat::expect_identical(out$datanames, c("c", "a", "b"))
 })
 
-testthat::test_that("module datanames is set to 'all' if transformer $datanames is 'all'", {
+testthat::test_that("module datanames is set to union(datanames, 'all') if transformer $datanames is 'all'", {
   transformer_w_datanames <- teal_transform_module(
     ui = function(id) NULL,
     server = function(id, data) {
@@ -551,7 +551,7 @@ testthat::test_that("module datanames is set to 'all' if transformer $datanames 
   )
 
   out <- module(datanames = "c", transformers = list(transformer_w_datanames))
-  testthat::expect_identical(out$datanames, "all")
+  testthat::expect_identical(out$datanames, c("c", "all"))
 })
 
 testthat::test_that("module datanames stays 'all' regardless of transformers", {

--- a/tests/testthat/test-modules.R
+++ b/tests/testthat/test-modules.R
@@ -551,7 +551,7 @@ testthat::test_that("module datanames is set to union(datanames, 'all') if trans
   )
 
   out <- module(datanames = "c", transformers = list(transformer_w_datanames))
-  testthat::expect_identical(out$datanames, c("c", "all"))
+  testthat::expect_identical(out$datanames, "all")
 })
 
 testthat::test_that("module datanames stays 'all' regardless of transformers", {


### PR DESCRIPTION
`module()$datanames` are affected by `datanames` parameter and `datanames` coming out of `transformers`.
So far this is not unified, and the outcome `$datanames` depend on the length of input of the transformers. 
They are different if the transformer has length 1. 

```r
# 0 transformers
example_module("mod-1", transformers = 
                 list(
                   
                 ), 
               datanames = c("ADSL", "ADTTE"))$datanames
# > [1] "ADSL"  "ADTTE" "all" 



# 1 transformer
example_module("mod-1", transformers = 
                 list(
                   teal_transform_module(ui = function(id) NULL, server = function(id, data) NULL)
                  ), 
               datanames = c("ADSL", "ADTTE"))$datanames
[1] "all" 



# 2 transformers
example_module("mod-1", transformers = 
                 list(
                   teal_transform_module(ui = function(id) NULL, server = function(id, data) NULL),
                   teal_transform_module(ui = function(id) NULL, server = function(id, data) NULL)
                 ), 
               datanames = c("ADSL", "ADTTE"))$datanames
# [1] "ADSL"  "ADTTE" "all" 
```

The solution is up to discussion, but for now I plan to unify to return `union(datanames, transformers$datanames)` as a result.
So if

- `modules(datanames = "all"` and `transfomers(datanames = "all"` we get `"all"`
- `modules(datanames = "custom"` and `transfomers(datanames = "all"` we get `c("custom", "all")`
- `modules(datanames = "all"` and `transfomers(datanames = "custom"` we get `"all"`
- `modules(datanames = "custom"` and `transfomers(datanames = "custom2"` we get `c("custom", "custom2")`


The main reason for this change is to unify and to have custom datanames returned in `module()$datanames` if any custom names are passed via `module(datanames = ` parameter.