### PR TITLE
disable lockfile generation in `callr`, `testthat::tests` and `R CMD CHECK`

### DIFF
--- a/R/module_teal_lockfile.R
+++ b/R/module_teal_lockfile.R
@@ -75,8 +75,6 @@ srv_teal_lockfile <- function(id) {
 
     lockfile_path <- "teal_app.lock"
     is_lockfile_enabled <- .is_lockfile_enabled()
-    cat('\n is_lockfile_enabled', is_lockfile_enabled, '\n')
-    cat('\n identical(Sys.getenv("TESTTHAT"), "true")', identical(Sys.getenv("TESTTHAT"), "true"), '\n')
     user_lockfile_path <- getOption("teal.lockfile.path", default = "")
     is_user_lockfile_set <- !identical(user_lockfile_path, "")
 

--- a/R/module_teal_lockfile.R
+++ b/R/module_teal_lockfile.R
@@ -74,7 +74,9 @@ srv_teal_lockfile <- function(id) {
     })
 
     lockfile_path <- "teal_app.lock"
-    is_lockfile_enabled <- isTRUE(getOption("teal.lockfile.enable"))
+    is_lockfile_enabled <- .is_lockfile_enabled()
+    cat('\n is_lockfile_enabled', is_lockfile_enabled, '\n')
+    cat('\n identical(Sys.getenv("TESTTHAT"), "true")', identical(Sys.getenv("TESTTHAT"), "true"), '\n')
     user_lockfile_path <- getOption("teal.lockfile.path", default = "")
     is_user_lockfile_set <- !identical(user_lockfile_path, "")
 
@@ -193,4 +195,20 @@ utils::globalVariables(c("opts", "sysenv", "libpaths", "wd", "lockfilepath", "ru
 #' @rdname module_teal_lockfile
 .is_lockfile_deps_installed <- function() {
   requireNamespace("mirai", quietly = TRUE) && requireNamespace("renv", quietly = TRUE)
+}
+
+#' @rdname module_teal_lockfile
+.is_lockfile_enabled <- function() {
+  if (isTRUE(getOption("teal.lockfile.enable"))) {
+    return(TRUE)
+  } else {
+    !(
+      identical(Sys.getenv("CALLR_IS_RUNNING"), "true") || # inside callr process
+      identical(Sys.getenv("TESTTHAT"), "true") || # inside devtools::test
+      !identical(Sys.getenv("QUARTO_PROJECT_ROOT"), "") || # inside Quarto process
+      (
+        ("CheckExEnv" %in% search()) || any(c("_R_CHECK_TIMINGS_", "_R_CHECK_LICENSE_") %in% names(Sys.getenv()))
+      ) # inside R CMD CHECK
+    )
+  }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,6 +5,7 @@
     !(
       identical(Sys.getenv("CALLR_IS_RUNNING"), "true") || # inside callr process
       identical(Sys.getenv("TESTTHAT"), "true") || # inside devtools::test
+      !identical(Sys.getenv("QUARTO_PROJECT_ROOT"), "") || # inside Quarto process
       (
         ("CheckExEnv" %in% search()) || any(c("_R_CHECK_TIMINGS_", "_R_CHECK_LICENSE_") %in% names(Sys.getenv()))
       ) # inside R CMD CHECK

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,18 @@
 .onLoad <- function(libname, pkgname) {
   # adapted from https://github.com/r-lib/devtools/blob/master/R/zzz.R
+
+  lockfile_flag <-
+    !(
+      identical(Sys.getenv("CALLR_IS_RUNNING"), "true") || # inside callr process
+      identical(Sys.getenv("TESTTHAT"), "true") || # inside devtools::test
+      (
+        ("CheckExEnv" %in% search()) || any(c("_R_CHECK_TIMINGS_", "_R_CHECK_LICENSE_") %in% names(Sys.getenv()))
+      ) # inside R CMD CHECK
+    )
+
   teal_default_options <- list(
     teal.show_js_log = FALSE,
-    teal.lockfile.enable = TRUE,
+    teal.lockfile.enable = lockfile_flag,
     shiny.sanitize.errors = FALSE
   )
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,19 +1,8 @@
 .onLoad <- function(libname, pkgname) {
   # adapted from https://github.com/r-lib/devtools/blob/master/R/zzz.R
 
-  lockfile_flag <-
-    !(
-      identical(Sys.getenv("CALLR_IS_RUNNING"), "true") || # inside callr process
-      identical(Sys.getenv("TESTTHAT"), "true") || # inside devtools::test
-      !identical(Sys.getenv("QUARTO_PROJECT_ROOT"), "") || # inside Quarto process
-      (
-        ("CheckExEnv" %in% search()) || any(c("_R_CHECK_TIMINGS_", "_R_CHECK_LICENSE_") %in% names(Sys.getenv()))
-      ) # inside R CMD CHECK
-    )
-
   teal_default_options <- list(
     teal.show_js_log = FALSE,
-    teal.lockfile.enable = lockfile_flag,
     shiny.sanitize.errors = FALSE
   )
 

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -19,3 +19,7 @@ if (isFALSE(getFromNamespace("on_cran", "testthat")()) && requireNamespace("with
     .local_envir = testthat::teardown_env()
   )
 }
+
+cat('\nIS_TESTING', Sys.getenv("TESTTHAT"), '\n')
+cat('\n teal.lockfile.enable: ',
+    getOption('teal.lockfile.enable'), '\n')

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -19,7 +19,3 @@ if (isFALSE(getFromNamespace("on_cran", "testthat")()) && requireNamespace("with
     .local_envir = testthat::teardown_env()
   )
 }
-
-cat('\nIS_TESTING', Sys.getenv("TESTTHAT"), '\n')
-cat('\n teal.lockfile.enable: ',
-    getOption('teal.lockfile.enable'), '\n')

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -1,9 +1,3 @@
-withr::local_options(
-  # we should't run lockfile process multiple times in tests as it starts background process which is not
-  # possible to kill once run. It means that background R sessions are being cumulated
-  list(teal.lockfile.enable = FALSE),
-  .local_envir = testthat::teardown_env()
-)
 
 # `opts_partial_match_old` is left for exclusions due to partial matching in dependent packages (i.e. not fixable here)
 # it might happen that it is not used right now, but it is left for possible future use

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -1,7 +1,5 @@
 # data ----
 testthat::test_that("init data accepts teal_data object", {
-  cat('\n teal.lockfile.enable: ',
-      getOption('teal.lockfile.enable'), '\n')
   testthat::expect_no_error(
     init(
       data = teal.data::teal_data(iris = iris),

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -1,5 +1,7 @@
 # data ----
 testthat::test_that("init data accepts teal_data object", {
+  cat('\n teal.lockfile.enable: ',
+      getOption('teal.lockfile.enable'), '\n')
   testthat::expect_no_error(
     init(
       data = teal.data::teal_data(iris = iris),


### PR DESCRIPTION
Part of https://github.com/insightsengineering/teal/pull/1263 and closes https://github.com/insightsengineering/teal/issues/1276

Local results of `shinytest2` tests

```r
══ Results ══════════════════════════════════════════════════════════════════════════
Duration: 540.8 s

── Skipped tests (6) ────────────────────────────────────────────────────────────────
• need a fix in a .slicesGlobal (1): test-module_teal.R:1139:11
• todo (5): test-module_teal.R:1404:7, test-module_teal.R:1411:5,
  test-module_teal.R:1414:5, test-module_teal.R:1673:5, test-module_teal.R:1731:5

[ FAIL 0 | WARN 0 | SKIP 6 | PASS 515 ]
```