### PR TITLE
Fix the datanames bug causing teal app to crash when `teal_data` has non standard object names

### DIFF
--- a/R/module_init_data.R
+++ b/R/module_init_data.R
@@ -111,6 +111,9 @@ srv_init_data <- function(id, data) {
   )
 
   tdata@verified <- data@verified
+  if (length(datanames(data))) {
+    datanames(tdata) <- datanames(data)
+  }
   tdata
 }
 

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -359,7 +359,9 @@ srv_teal_module.teal_module <- function(id,
 
 .resolve_module_datanames <- function(data, modules) {
   stopifnot("data_rv must be teal_data object." = inherits(data, "teal_data"))
-  if (is.null(modules$datanames) || identical(modules$datanames, "all")) {
+  if (length(datanames(data))) {
+    .topologically_sort_datanames(datanames(data), teal.data::join_keys(data))
+  } else if (is.null(modules$datanames) || identical(modules$datanames, "all")) {
     .topologically_sort_datanames(ls(teal.code::get_env(data)), teal.data::join_keys(data))
   } else {
     intersect(

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,10 +74,13 @@ get_teal_bs_theme <- function() {
 #' @param datanames (`character`) vector of data set names to include; must be subset of `datanames(x)`
 #' @return A `FilteredData` object.
 #' @keywords internal
-teal_data_to_filtered_data <- function(x, datanames = ls(teal.code::get_env(x))) {
+teal_data_to_filtered_data <- function(x, datanames = teal.data::datanames(data)) {
   checkmate::assert_class(x, "teal_data")
   checkmate::assert_character(datanames, min.chars = 1L, any.missing = FALSE)
   # Otherwise, FilteredData will be created in the modules' scope later
+  if (!length(datanames)) {
+    datanames <- ls(teal.code::get_env(x))
+  }
   teal.slice::init_filtered_data(
     x = Filter(
       length,

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,7 +74,7 @@ get_teal_bs_theme <- function() {
 #' @param datanames (`character`) vector of data set names to include; must be subset of `datanames(x)`
 #' @return A `FilteredData` object.
 #' @keywords internal
-teal_data_to_filtered_data <- function(x, datanames = teal.data::datanames(data)) {
+teal_data_to_filtered_data <- function(x, datanames = teal.data::datanames(x)) {
   checkmate::assert_class(x, "teal_data")
   checkmate::assert_character(datanames, min.chars = 1L, any.missing = FALSE)
   # Otherwise, FilteredData will be created in the modules' scope later

--- a/man/teal_data_to_filtered_data.Rd
+++ b/man/teal_data_to_filtered_data.Rd
@@ -4,7 +4,7 @@
 \alias{teal_data_to_filtered_data}
 \title{Create a \code{FilteredData}}
 \usage{
-teal_data_to_filtered_data(x, datanames = teal.data::datanames(data))
+teal_data_to_filtered_data(x, datanames = teal.data::datanames(x))
 }
 \arguments{
 \item{x}{(\code{teal_data}) object}

--- a/man/teal_data_to_filtered_data.Rd
+++ b/man/teal_data_to_filtered_data.Rd
@@ -4,7 +4,7 @@
 \alias{teal_data_to_filtered_data}
 \title{Create a \code{FilteredData}}
 \usage{
-teal_data_to_filtered_data(x, datanames = ls(teal.code::get_env(x)))
+teal_data_to_filtered_data(x, datanames = teal.data::datanames(data))
 }
 \arguments{
 \item{x}{(\code{teal_data}) object}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -45,6 +45,20 @@ test_that("teal_data_to_filtered_data return FilteredData class", {
   testthat::expect_s3_class(teal_data_to_filtered_data(teal_data), "FilteredData")
 })
 
+test_that("teal_data_to_filtered_data creates FilterData class with datanames that are passed", {
+  teal_data <- within(
+    teal.data::teal_data(),
+    {
+      iris <- head(iris)
+      mtcars <- head(mtcars)
+    }
+  )
+  teal.data::datanames(teal_data) <- "iris"
+
+  fd <- teal_data_to_filtered_data(teal_data)
+  testthat::expect_equal(fd$datanames(), "iris")
+})
+
 test_that("validate_app_title_tag works on validating the title tag", {
   valid_title <- tags$head(
     tags$title("title"),


### PR DESCRIPTION
Closes #1366 