### PR TITLE
210 substitute `teal.data::get_code` with `teal.code::get_code`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ BugReports: https://github.com/insightsengineering/teal/issues
 Depends:
     R (>= 4.0),
     shiny (>= 1.8.1),
-    teal.data (> 0.6.0.9014),
+    teal.data (>= 0.6.0.9014),
     teal.slice (>= 0.5.1.9009)
 Imports:
     checkmate (>= 2.1.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal
 Title: Exploratory Web Apps for Analyzing Clinical Trials Data
-Version: 0.15.2.9071
-Date: 2024-10-14
+Version: 0.15.2.9072
+Date: 2024-10-17
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9533-457X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ BugReports: https://github.com/insightsengineering/teal/issues
 Depends:
     R (>= 4.0),
     shiny (>= 1.8.1),
-    teal.data (> 0.6.0.9007),
+    teal.data (> 0.6.0.9014),
     teal.slice (>= 0.5.1.9009)
 Imports:
     checkmate (>= 2.1.0),
@@ -48,7 +48,7 @@ Imports:
     rlang (>= 1.0.0),
     shinyjs,
     stats,
-    teal.code (>= 0.5.0),
+    teal.code (>= 0.5.0.9011),
     teal.logger (>= 0.2.0),
     teal.reporter (>= 0.3.1.9004),
     teal.widgets (>= 0.4.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal 0.15.2.9071
+# teal 0.15.2.9072
 
 ### New features
 

--- a/R/module_filter_data.R
+++ b/R/module_filter_data.R
@@ -73,10 +73,8 @@ srv_filter_data <- function(id, datasets, active_datanames, data_rv, is_active) 
   previous_signature <- reactiveVal(NULL)
   filter_changed <- reactive({
     req(inherits(datasets(), "FilteredData"))
-    data_q <- data_rv()
-    class(data_q) <- "qenv"
     new_signature <- c(
-      teal.code::get_code(data_q),
+      teal.code::get_code(data_rv()),
       .get_filter_expr(datasets = datasets(), datanames = active_datanames())
     )
     if (!identical(previous_signature(), new_signature)) {

--- a/R/module_filter_data.R
+++ b/R/module_filter_data.R
@@ -73,8 +73,10 @@ srv_filter_data <- function(id, datasets, active_datanames, data_rv, is_active) 
   previous_signature <- reactiveVal(NULL)
   filter_changed <- reactive({
     req(inherits(datasets(), "FilteredData"))
+    data_q <- data_rv()
+    class(data_q) <- "qenv"
     new_signature <- c(
-      teal.data::get_code(data_rv()),
+      teal.code::get_code(data_q),
       .get_filter_expr(datasets = datasets(), datanames = active_datanames())
     )
     if (!identical(previous_signature(), new_signature)) {

--- a/R/teal_data_utils.R
+++ b/R/teal_data_utils.R
@@ -48,15 +48,12 @@ NULL
     return(teal_data())
   }
 
-  data_q <- data
-  class(data_q) <- "qenv"
-
   new_data <- do.call(
     teal.data::teal_data,
     args = c(
       mget(x = datanames_corrected_with_raw, envir = teal.code::get_env(data)),
       list(
-        code = teal.code::get_code(data_q, names = datanames_corrected_with_raw),
+        code = teal.code::get_code(data, names = datanames_corrected_with_raw),
         join_keys = teal.data::join_keys(data)[datanames_corrected]
       )
     )

--- a/R/teal_data_utils.R
+++ b/R/teal_data_utils.R
@@ -48,12 +48,15 @@ NULL
     return(teal_data())
   }
 
+  data_q <- data
+  class(data_q) <- "qenv"
+
   new_data <- do.call(
     teal.data::teal_data,
     args = c(
       mget(x = datanames_corrected_with_raw, envir = teal.code::get_env(data)),
       list(
-        code = teal.data::get_code(data, datanames = datanames_corrected_with_raw),
+        code = teal.code::get_code(data_q, names = datanames_corrected_with_raw),
         join_keys = teal.data::join_keys(data)[datanames_corrected]
       )
     )


### PR DESCRIPTION
Partner to 
- https://github.com/insightsengineering/teal.data/pull/343 
- https://github.com/insightsengineering/teal.code/pull/214

Replace `teal.data::get_code()` (that worked on `teal_data()`) with `teal.code::get_code()` (that works on `qenv`).