### PR TITLE
The documentation of `check_modules_datanames()`

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -213,7 +213,7 @@ init <- function(data,
 
     is_modules_ok <- check_modules_datanames(modules, ls(teal.code::get_env(data)))
     if (!isTRUE(is_modules_ok) && length(unlist(extract_transformers(modules))) == 0) {
-      warning(is_modules_ok)
+      warning(is_modules_ok, call. = FALSE)
     }
 
     is_filter_ok <- check_filter_datanames(filter, ls(teal.code::get_env(data)))

--- a/R/init.R
+++ b/R/init.R
@@ -213,7 +213,7 @@ init <- function(data,
 
     is_modules_ok <- check_modules_datanames(modules, ls(teal.code::get_env(data)))
     if (!isTRUE(is_modules_ok) && length(unlist(extract_transformers(modules))) == 0) {
-      lapply(is_modules_ok$string, warning, call. = FALSE)
+      warning(is_modules_ok)
     }
 
     is_filter_ok <- check_filter_datanames(filter, ls(teal.code::get_env(data)))

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -210,6 +210,7 @@ srv_teal <- function(id, data, modules, filter = teal_slices()) {
     data_load_status <- reactive({
       if (inherits(data_pulled(), "teal_data")) {
         "ok"
+        # todo: should we hide warnings on top for a data?
       } else if (inherits(data, "teal_data_module")) {
         "teal_data_module failed"
       } else {

--- a/R/module_teal_data.R
+++ b/R/module_teal_data.R
@@ -222,14 +222,13 @@ srv_check_shiny_warnings <- function(id, data, modules) {
   moduleServer(id, function(input, output, session) {
     output$message <- renderUI({
       if (inherits(data(), "teal_data")) {
-        is_modules_ok <- check_modules_datanames(modules = modules, datanames = ls(teal.code::get_env(data())))
+        is_modules_ok <- check_modules_datanames(
+          modules = modules, datanames = ls(teal.code::get_env(data())), as_html = TRUE
+        )
         if (!isTRUE(is_modules_ok)) {
           tags$div(
             class = "teal-output-warning",
-            is_modules_ok$html(
-              # Show modules prefix on message only in teal_data_module tab
-              grepl(sprintf("data-teal_data_module-%s", id), session$ns(NULL), fixed = TRUE)
-            )
+            is_modules_ok
           )
         }
       }

--- a/R/module_teal_data.R
+++ b/R/module_teal_data.R
@@ -226,10 +226,7 @@ srv_check_shiny_warnings <- function(id, data, modules) {
           modules = modules, datanames = ls(teal.code::get_env(data()))
         )
         if (!isTRUE(is_modules_ok)) {
-          tags$div(
-            class = "teal-output-warning",
-            is_modules_ok
-          )
+          tags$div(is_modules_ok, class = "teal-output-warning")
         }
       }
     })

--- a/R/module_teal_data.R
+++ b/R/module_teal_data.R
@@ -222,8 +222,8 @@ srv_check_shiny_warnings <- function(id, data, modules) {
   moduleServer(id, function(input, output, session) {
     output$message <- renderUI({
       if (inherits(data(), "teal_data")) {
-        is_modules_ok <- check_modules_datanames(
-          modules = modules, datanames = ls(teal.code::get_env(data())), as_html = TRUE
+        is_modules_ok <- check_modules_datanames_html(
+          modules = modules, datanames = ls(teal.code::get_env(data()))
         )
         if (!isTRUE(is_modules_ok)) {
           tags$div(

--- a/R/utils.R
+++ b/R/utils.R
@@ -203,7 +203,7 @@ check_modules_datanames_html <- function(modules,
 
 #' Recursively checks modules and returns list for every datanames mismatch between module and data
 #' @noRd
-check_modules_datanames_recursive <- function(modules, datanames) {
+check_modules_datanames_recursive <- function(modules, datanames) { # nolint: object_name_length
   checkmate::assert_multi_class(modules, c("teal_module", "teal_modules"))
   checkmate::assert_character(datanames)
   if (inherits(modules, "teal_modules")) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -220,7 +220,7 @@ to_html_code_list <- function(x) {
       tagList(
         tags$code(x[.ix]),
         if (.ix != length(x)) {
-          tags$span(ifelse(.ix == length(x) - 1, " and ", ", "))
+          if (.ix == length(x) - 1) tags$span(" and ") else tags$span(", ", .noWS = "before")
         }
       )
     })

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,13 +123,15 @@ report_card_template <- function(title, label, description = NULL, with_filter, 
 #' Check `datanames` in modules
 #'
 #' This function ensures specified `datanames` in modules match those in the data object,
-#' returning error messages or `TRUE` for successful validation.
+#' returning error messages or `TRUE` for successful validation. Function can return error message
+#' in two forms `character(1)` for basic assertion usage and `shiny.tag.list` when message is
+#' displayed in the app.
 #'
 #' @param modules (`teal_modules`) object
 #' @param datanames (`character`) names of datasets available in the `data` object
-#' @param as_html (`logical(1)`) whether message should be returned in form of formatted `html`.
+#' @param as_html (`logical(1)`) whether message should be returned in form of formatted `html` (`shiny.tag.list`).
 #'
-#' @return `TRUE` if validation passes, otherwise `character` or `shiny.tag.list`
+#' @return `TRUE` if validation passes, otherwise `character(1)` or `shiny.tag.list`
 #' @keywords internal
 check_modules_datanames <- function(modules, datanames, as_html = FALSE) {
   checkmate::assert_multi_class(modules, c("teal_module", "teal_modules"))
@@ -157,14 +159,14 @@ check_modules_datanames <- function(modules, datanames, as_html = FALSE) {
         check_datanames,
         function(mod) {
           sprintf(
-            "Dataset(s) (%s) are missing for module %s.",
+            "Datasets %s are missing for module %s.",
             toString(dQuote(mod$missing_datanames, q = FALSE)),
             toString(dQuote(mod$label, q = FALSE))
           )
         }
       )
       sprintf(
-        "%s\nDataset(s) available in data: %s",
+        "%s Datasets available in data: %s",
         paste(modules_msg, collapse = "\n"),
         toString(dQuote(datanames, q = FALSE))
       )

--- a/R/utils.R
+++ b/R/utils.R
@@ -134,24 +134,13 @@ report_card_template <- function(title, label, description = NULL, with_filter, 
 #' @return `TRUE` if validation passes, otherwise `character(1)` or `shiny.tag.list`
 #' @keywords internal
 check_modules_datanames <- function(modules, datanames) {
-  check_datanames <- check_modules_datanames_recursive(modules, datanames)
-  if (length(check_datanames)) {
-    modules_msg <- sapply(check_datanames, function(mod) {
-      sprintf(
-        "%s %s %s missing for module %s.",
-        if (length(mod$missing_datanames) > 1) "Datasets" else "Dataset",
-        toString(dQuote(mod$missing_datanames, q = FALSE)),
-        if (length(mod$missing_datanames) > 1) "are" else "is",
-        toString(dQuote(mod$label, q = FALSE))
-      )
-    })
-    sprintf(
-      "%s Datasets available in data: %s",
-      paste(modules_msg, collapse = "\n"),
-      toString(dQuote(datanames, q = FALSE))
-    )
+  out <- check_modules_datanames_html(modules, datanames)
+  if (inherits(out, "shiny.tag.list")) {
+    out_with_ticks <- gsub("<code>|</code>", "`", toString(out))
+    out_text <- trimws(gsub("<[^<>]+>", "", toString(out_with_ticks)))
+    gsub("[[:space:]]+", " ", out_text)
   } else {
-    TRUE
+    out
   }
 }
 
@@ -174,7 +163,7 @@ check_modules_datanames_html <- function(modules,
             tags$span(
               paste0(
                 if (length(mod$missing_datanames) > 1) "are missing" else "is missing",
-                if (show_module_info) sprintf(" for tab '%s'.", mod$label) else "."
+                if (show_module_info) sprintf(" for module '%s'.", mod$label) else "."
               )
             )
           ),

--- a/R/utils.R
+++ b/R/utils.R
@@ -138,7 +138,8 @@ check_modules_datanames <- function(modules, datanames) {
   if (length(check_datanames)) {
     modules_msg <- sapply(check_datanames, function(mod) {
       sprintf(
-        "Datasets %s are missing for module %s.",
+        "%s %s are missing for module %s.",
+        `if`(length(mod$missing_datanames) > 1, "Datasets", "Dataset"),
         toString(dQuote(mod$missing_datanames, q = FALSE)),
         toString(dQuote(mod$label, q = FALSE))
       )

--- a/R/utils.R
+++ b/R/utils.R
@@ -138,9 +138,10 @@ check_modules_datanames <- function(modules, datanames) {
   if (length(check_datanames)) {
     modules_msg <- sapply(check_datanames, function(mod) {
       sprintf(
-        "%s %s are missing for module %s.",
+        "%s %s %s missing for module %s.",
         `if`(length(mod$missing_datanames) > 1, "Datasets", "Dataset"),
         toString(dQuote(mod$missing_datanames, q = FALSE)),
+        `if`(length(mod$missing_datanames) > 1, "are", "is"),
         toString(dQuote(mod$label, q = FALSE))
       )
     })

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,30 +169,30 @@ check_modules_datanames_html <- function(modules,
       function(mod) {
         tagList(
           tags$span(
-            tags$span(`if`(length(mod$missing_datanames) > 1, "Datasets", "Dataset")),
+            tags$span(if (length(mod$missing_datanames) == 1) "Dataset" else "Datasets"),
             to_html_code_list(mod$missing_datanames),
             tags$span(
               paste0(
-                `if`(length(mod$missing_datanames) > 1, "are missing", "is missing"),
-                `if`(show_module_info, sprintf(" for tab '%s'.", mod$label), ".")
+                if (length(mod$missing_datanames) > 1) "are missing" else "is missing",
+                if (show_module_info) sprintf(" for tab '%s'.", mod$label) else "."
               )
-            ),
-            if (length(mod$datanames) >= 1) {
+            )
+          ),
+          if (length(datanames) >= 1) {
+            tagList(
+              tags$span(if (length(datanames) == 1) "Dataset" else "Datasets"),
+              tags$span("available in data:"),
               tagList(
-                tags$span(`if`(length(mod$datanames) > 1, "Datasets", "Dataset")),
-                tags$span("available in data:"),
-                tagList(
-                  tags$span(
-                    to_html_code_list(mod$datanames),
-                    tags$span(".", .noWS = "outside"),
-                    .noWS = c("outside")
-                  )
+                tags$span(
+                  to_html_code_list(datanames),
+                  tags$span(".", .noWS = "outside"),
+                  .noWS = c("outside")
                 )
               )
-            } else {
-              tags$span("No datasets are available in data.")
-            }
-          ),
+            )
+          } else {
+            tags$span("No datasets are available in data.")
+          },
           tags$br(.noWS = "before")
         )
       }
@@ -215,7 +215,6 @@ check_modules_datanames_recursive <- function(modules, datanames) { # nolint: ob
     if (length(missing_datanames)) {
       list(list(
         label = modules$label,
-        dataname = modules$datanames,
         missing_datanames = missing_datanames
       ))
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -137,8 +137,8 @@ check_modules_datanames <- function(modules, datanames) {
   out <- check_modules_datanames_html(modules, datanames)
   if (inherits(out, "shiny.tag.list")) {
     out_with_ticks <- gsub("<code>|</code>", "`", toString(out))
-    out_text <- trimws(gsub("<[^<>]+>", "", toString(out_with_ticks)))
-    gsub("[[:space:]]+", " ", out_text)
+    out_text <- gsub("<[^<>]+>", "", toString(out_with_ticks))
+    trimws(gsub("[[:space:]]+", " ", out_text))
   } else {
     out
   }
@@ -148,7 +148,7 @@ check_modules_datanames <- function(modules, datanames) {
 check_modules_datanames_html <- function(modules,
                                          datanames) {
   check_datanames <- check_modules_datanames_recursive(modules, datanames)
-  show_module_info <- inherits(modules, "teal_modules")
+  show_module_info <- inherits(modules, "teal_modules") # used in two contexts - module and app
   if (!length(check_datanames)) {
     return(TRUE)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -139,9 +139,9 @@ check_modules_datanames <- function(modules, datanames) {
     modules_msg <- sapply(check_datanames, function(mod) {
       sprintf(
         "%s %s %s missing for module %s.",
-        `if`(length(mod$missing_datanames) > 1, "Datasets", "Dataset"),
+        if (length(mod$missing_datanames) > 1) "Datasets" else "Dataset",
         toString(dQuote(mod$missing_datanames, q = FALSE)),
-        `if`(length(mod$missing_datanames) > 1, "are", "is"),
+        if (length(mod$missing_datanames) > 1) "are" else "is",
         toString(dQuote(mod$label, q = FALSE))
       )
     })
@@ -160,45 +160,44 @@ check_modules_datanames_html <- function(modules,
                                          datanames) {
   check_datanames <- check_modules_datanames_recursive(modules, datanames)
   show_module_info <- inherits(modules, "teal_modules")
-  if (length(check_datanames)) {
-    shiny::tagList(
-      lapply(
-        check_datanames,
-        function(mod) {
-          tagList(
+  if (!length(check_datanames)) {
+    return(TRUE)
+  }
+  shiny::tagList(
+    lapply(
+      check_datanames,
+      function(mod) {
+        tagList(
+          tags$span(
+            tags$span(`if`(length(mod$missing_datanames) > 1, "Datasets", "Dataset")),
+            to_html_code_list(mod$missing_datanames),
             tags$span(
-              tags$span(`if`(length(mod$missing_datanames) > 1, "Datasets", "Dataset")),
-              to_html_code_list(mod$missing_datanames),
-              tags$span(
-                paste0(
-                  `if`(length(mod$missing_datanames) > 1, "are missing", "is missing"),
-                  `if`(show_module_info, sprintf(" for tab '%s'.", mod$label), ".")
-                )
-              ),
-              if (length(mod$datanames) >= 1) {
+              paste0(
+                `if`(length(mod$missing_datanames) > 1, "are missing", "is missing"),
+                `if`(show_module_info, sprintf(" for tab '%s'.", mod$label), ".")
+              )
+            ),
+            if (length(mod$datanames) >= 1) {
+              tagList(
+                tags$span(`if`(length(mod$datanames) > 1, "Datasets", "Dataset")),
+                tags$span("available in data:"),
                 tagList(
-                  tags$span(`if`(length(mod$datanames) > 1, "Datasets", "Dataset")),
-                  tags$span("available in data:"),
-                  tagList(
-                    tags$span(
-                      to_html_code_list(mod$datanames),
-                      tags$span(".", .noWS = "outside"),
-                      .noWS = c("outside")
-                    )
+                  tags$span(
+                    to_html_code_list(mod$datanames),
+                    tags$span(".", .noWS = "outside"),
+                    .noWS = c("outside")
                   )
                 )
-              } else {
-                tags$span("No datasets are available in data.")
-              }
-            ),
-            tags$br(.noWS = "before")
-          )
-        }
-      )
+              )
+            } else {
+              tags$span("No datasets are available in data.")
+            }
+          ),
+          tags$br(.noWS = "before")
+        )
+      }
     )
-  } else {
-    TRUE
-  }
+  )
 }
 
 #' Recursively checks modules and returns list for every datanames mismatch between module and data
@@ -208,7 +207,7 @@ check_modules_datanames_recursive <- function(modules, datanames) { # nolint: ob
   checkmate::assert_character(datanames)
   if (inherits(modules, "teal_modules")) {
     unlist(
-      lapply(modules$children, function(mod) check_modules_datanames_recursive(mod, datanames)),
+      lapply(modules$children, check_modules_datanames_recursive, datanames = datanames),
       recursive = FALSE
     )
   } else {
@@ -225,7 +224,7 @@ check_modules_datanames_recursive <- function(modules, datanames) { # nolint: ob
 
 #' Convert character vector to html code separated with commas and "and"
 #' @noRd
-to_html_code_list <- function(x) { # nolint: object_name.
+to_html_code_list <- function(x) {
   checkmate::assert_character(x)
   do.call(
     tagList,

--- a/man/check_modules_datanames.Rd
+++ b/man/check_modules_datanames.Rd
@@ -2,27 +2,28 @@
 % Please edit documentation in R/utils.R
 \name{check_modules_datanames}
 \alias{check_modules_datanames}
-\alias{recursive_check_datanames}
+\alias{check_modules_datanames_html}
 \title{Check \code{datanames} in modules}
 \usage{
-check_modules_datanames(modules, datanames, as_html = FALSE)
+check_modules_datanames(modules, datanames)
 
-recursive_check_datanames(modules, datanames)
+check_modules_datanames_html(modules, datanames)
 }
 \arguments{
 \item{modules}{(\code{teal_modules}) object}
 
 \item{datanames}{(\code{character}) names of datasets available in the \code{data} object}
-
-\item{as_html}{(\code{logical(1)}) whether message should be returned in form of formatted \code{html} (\code{shiny.tag.list}).}
 }
 \value{
 \code{TRUE} if validation passes, otherwise \code{character(1)} or \code{shiny.tag.list}
 }
 \description{
-This function ensures specified \code{datanames} in modules match those in the data object,
-returning error messages or \code{TRUE} for successful validation. Function can return error message
-in two forms \code{character(1)} for basic assertion usage and \code{shiny.tag.list} when message is
-displayed in the app.
+These functions check if specified \code{datanames} in modules match those in the data object,
+returning error messages or \code{TRUE} for successful validation. Two functions return error message
+in different forms:
+\itemize{
+\item \code{check_modules_datanames} returns \code{character(1)} for basic assertion usage
+\item \code{check_modules_datanames_html} returns \code{shiny.tag.list} to display it in the app.
+}
 }
 \keyword{internal}

--- a/man/check_modules_datanames.Rd
+++ b/man/check_modules_datanames.Rd
@@ -14,13 +14,15 @@ recursive_check_datanames(modules, datanames)
 
 \item{datanames}{(\code{character}) names of datasets available in the \code{data} object}
 
-\item{as_html}{(\code{logical(1)}) whether message should be returned in form of formatted \code{html}.}
+\item{as_html}{(\code{logical(1)}) whether message should be returned in form of formatted \code{html} (\code{shiny.tag.list}).}
 }
 \value{
-\code{TRUE} if validation passes, otherwise \code{character} or \code{shiny.tag.list}
+\code{TRUE} if validation passes, otherwise \code{character(1)} or \code{shiny.tag.list}
 }
 \description{
 This function ensures specified \code{datanames} in modules match those in the data object,
-returning error messages or \code{TRUE} for successful validation.
+returning error messages or \code{TRUE} for successful validation. Function can return error message
+in two forms \code{character(1)} for basic assertion usage and \code{shiny.tag.list} when message is
+displayed in the app.
 }
 \keyword{internal}

--- a/man/check_modules_datanames.Rd
+++ b/man/check_modules_datanames.Rd
@@ -2,17 +2,22 @@
 % Please edit documentation in R/utils.R
 \name{check_modules_datanames}
 \alias{check_modules_datanames}
+\alias{recursive_check_datanames}
 \title{Check \code{datanames} in modules}
 \usage{
-check_modules_datanames(modules, datanames)
+check_modules_datanames(modules, datanames, as_html = FALSE)
+
+recursive_check_datanames(modules, datanames)
 }
 \arguments{
 \item{modules}{(\code{teal_modules}) object}
 
 \item{datanames}{(\code{character}) names of datasets available in the \code{data} object}
+
+\item{as_html}{(\code{logical(1)}) whether message should be returned in form of formatted \code{html}.}
 }
 \value{
-A \code{character(1)} containing error message or \code{TRUE} if validation passes.
+\code{TRUE} if validation passes, otherwise \code{character} or \code{shiny.tag.list}
 }
 \description{
 This function ensures specified \code{datanames} in modules match those in the data object,

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -64,7 +64,7 @@ testthat::test_that(
         data = teal.data::teal_data(mtcars = mtcars),
         modules = list(example_module(datanames = "iris"))
       ),
-      "Dataset \"iris\" is missing for module \"example teal module\". Datasets available in data: \"mtcars\""
+      "Dataset `iris` is missing for module 'example teal module'. Dataset available in data: `mtcars`."
     )
   }
 )
@@ -77,7 +77,7 @@ testthat::test_that(
         data = teal.data::teal_data(mtcars = mtcars),
         modules = list(example_module(datanames = c("a", "b")))
       ),
-      "Datasets \"a\", \"b\" are missing for module \"example teal module\". Datasets available in data: \"mtcars\""
+      "Datasets `a` and `b` are missing for module 'example teal module'. Dataset available in data: `mtcars`."
     )
   }
 )

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -64,7 +64,7 @@ testthat::test_that(
         data = teal.data::teal_data(mtcars = mtcars),
         modules = list(example_module(datanames = "iris"))
       ),
-      '"Dataset(s) ("iris") are missing for module "example teal module".\nDataset(s) available in data: "mtcars"'
+      'Datasets "iris" are missing for module "example teal module". Datasets available in data: "mtcars"'
     )
   }
 )

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -64,7 +64,7 @@ testthat::test_that(
         data = teal.data::teal_data(mtcars = mtcars),
         modules = list(example_module(datanames = "iris"))
       ),
-      'Datasets "iris" are missing for module "example teal module". Datasets available in data: "mtcars"'
+      'Dataset "iris" are missing for module "example teal module". Datasets available in data: "mtcars"'
     )
   }
 )

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -64,7 +64,7 @@ testthat::test_that(
         data = teal.data::teal_data(mtcars = mtcars),
         modules = list(example_module(datanames = "iris"))
       ),
-      "Dataset \"iris\" is missing for tab 'example teal module'. Dataset available in data: \"mtcars\"."
+      '"Dataset(s) ("iris") are missing for module "example teal module".\nDataset(s) available in data: "mtcars"'
     )
   }
 )

--- a/tests/testthat/test-init.R
+++ b/tests/testthat/test-init.R
@@ -64,7 +64,20 @@ testthat::test_that(
         data = teal.data::teal_data(mtcars = mtcars),
         modules = list(example_module(datanames = "iris"))
       ),
-      'Dataset "iris" are missing for module "example teal module". Datasets available in data: "mtcars"'
+      "Dataset \"iris\" is missing for module \"example teal module\". Datasets available in data: \"mtcars\""
+    )
+  }
+)
+
+testthat::test_that(
+  "init throws warning when datanames in modules incompatible w/ datanames in data and there is no transformers",
+  {
+    testthat::expect_warning(
+      init(
+        data = teal.data::teal_data(mtcars = mtcars),
+        modules = list(example_module(datanames = c("a", "b")))
+      ),
+      "Datasets \"a\", \"b\" are missing for module \"example teal module\". Datasets available in data: \"mtcars\""
     )
   }
 )

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -655,7 +655,7 @@ testthat::describe("srv_teal teal_modules", {
                 )
               )
             ),
-            "Datasets missing1 and missing2 are missing for tab 'module_1'. Dataset available in data: mtcars."
+            "Datasets missing1 and missing2 are missing for module 'module_1'. Dataset available in data: mtcars."
           )
         }
       )


### PR DESCRIPTION
Closes #1321 
Little refurnishment:
- splitted `check_modules_datanames` to two functions, one to return `character` and other to return `shiny.tag.list`
- Renamed related utilities to better fit to what they do.
