### PR TITLE
Unify `#@linksto` usage

### DIFF
--- a/R/module_filter_data.R
+++ b/R/module_filter_data.R
@@ -58,7 +58,7 @@ srv_filter_data <- function(id, datasets, active_datanames, data_rv, is_active) 
       ".raw_data <- list2env(list(",
       toString(sprintf("%1$s = %1$s", sapply(datanames, as.name))),
       "))\n",
-      "lockEnvironment(.raw_data) #@linksto .raw_data" # this is environment and it is shared by qenvs. CAN'T MODIFY!
+      "lockEnvironment(.raw_data) # @linksto .raw_data" # this is environment and it is shared by qenvs. CAN'T MODIFY!
     )
   )
   filtered_code <- .get_filter_expr(datasets = datasets, datanames = datanames)

--- a/R/module_init_data.R
+++ b/R/module_init_data.R
@@ -128,7 +128,7 @@ srv_init_data <- function(id, data) {
     function(dataname, datasets) {
       hash <- rlang::hash(data[[dataname]])
       sprintf(
-        "stopifnot(%s == %s) # @linksto %s",
+        "stopifnot(%s == %s) #@linksto %s",
         deparse1(bquote(rlang::hash(.(as.name(dataname))))),
         deparse1(hash),
         dataname


### PR DESCRIPTION
This does not change any behavior of anything.
This is just consistency management with `#@linksto` tag that we have for `lockEnvironment(.raw_data)`

https://github.com/search?q=repo%3Ainsightsengineering%2Fteal+%23+%40linksto&type=code

<img width="610" alt="image" src="https://github.com/user-attachments/assets/a0fc9038-5826-42a9-823d-3a2936d4008c">
