### PR TITLE
Update versions of `teal.data` and `teal.code`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Depends:
     R (>= 4.0),
     shiny (>= 1.8.1),
     teal.data (>= 0.6.0.9017),
-    teal.slice (>= 0.5.1.9015)
+    teal.slice (>= 0.5.1.9009)
 Imports:
     checkmate (>= 2.1.0),
     crayon,
@@ -49,7 +49,7 @@ Imports:
     rlang (>= 1.0.0),
     shinyjs,
     stats,
-    teal.code (>= 0.5.0.9012),
+    teal.code (>= 0.5.0.9015),
     teal.logger (>= 0.2.0),
     teal.reporter (>= 0.3.1.9004),
     teal.widgets (>= 0.4.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,8 @@ BugReports: https://github.com/insightsengineering/teal/issues
 Depends:
     R (>= 4.0),
     shiny (>= 1.8.1),
-    teal.data (>= 0.6.0.9015),
-    teal.slice (>= 0.5.1.9009)
+    teal.data (>= 0.6.0.9017),
+    teal.slice (>= 0.5.1.9015)
 Imports:
     checkmate (>= 2.1.0),
     crayon,


### PR DESCRIPTION
Since we introduced `[.teal_data` we need to vbump dependencies of `teal.code` and `teal.data`