### PR TITLE
Fixes `setup-r-dependencies` by adding `rtables.officer`

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -50,6 +50,7 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables.officer
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,17 +15,18 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  LOOKUP_REFS: |
+    insightsengineering/teal.data
+    insightsengineering/teal.slice
+    insightsengineering/teal.code
+    insightsengineering/teal.logger
+    insightsengineering/teal.reporter
+    insightsengineering/teal.widgets
+    insightsengineering/rtables
+    insightsengineering/rtables.officer
+
 jobs:
-  env:
-    LOOKUP_REFS: |
-      insightsengineering/teal.data
-      insightsengineering/teal.slice
-      insightsengineering/teal.code
-      insightsengineering/teal.logger
-      insightsengineering/teal.reporter
-      insightsengineering/teal.widgets
-      insightsengineering/rtables
-      insightsengineering/rtables.officer
   audit:
     name: Audit Dependencies 🕵️‍♂️
     uses: insightsengineering/r.pkg.template/.github/workflows/audit.yaml@main

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,17 +1,6 @@
 ---
 name: Check 🛠
 
-env:
-  LOOKUP_REFS: |
-    insightsengineering/teal.data
-    insightsengineering/teal.slice
-    insightsengineering/teal.code
-    insightsengineering/teal.logger
-    insightsengineering/teal.reporter
-    insightsengineering/teal.widgets
-    insightsengineering/rtables
-    insightsengineering/rtables.officer
-
 on:
   pull_request:
     types:
@@ -54,7 +43,15 @@ jobs:
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
       deps-installation-method: setup-r-dependencies
-      lookup-refs: ${{ env.LOOKUP_REFS }}
+      lookup-refs: |
+        insightsengineering/teal.data
+        insightsengineering/teal.slice
+        insightsengineering/teal.code
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
 
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
@@ -78,7 +75,15 @@ jobs:
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
-      lookup-refs: ${{ env.LOOKUP_REFS }}
+      lookup-refs: |
+        insightsengineering/teal.data
+        insightsengineering/teal.slice
+        insightsengineering/teal.code
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
 
   coverage:
     name: Coverage 📔
@@ -89,7 +94,15 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: ${{ env.LOOKUP_REFS }}
+      lookup-refs: |
+        insightsengineering/teal.data
+        insightsengineering/teal.slice
+        insightsengineering/teal.code
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -102,7 +115,15 @@ jobs:
     with:
       auto-update: true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: ${{ env.LOOKUP_REFS }}
+      lookup-refs: |
+        insightsengineering/teal.data
+        insightsengineering/teal.slice
+        insightsengineering/teal.code
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -99,6 +99,8 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,17 @@
 ---
 name: Check 🛠
 
+env:
+  LOOKUP_REFS: |
+    insightsengineering/teal.data
+    insightsengineering/teal.slice
+    insightsengineering/teal.code
+    insightsengineering/teal.logger
+    insightsengineering/teal.reporter
+    insightsengineering/teal.widgets
+    insightsengineering/rtables
+    insightsengineering/rtables.officer
+
 on:
   pull_request:
     types:
@@ -14,17 +25,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-
-env:
-  LOOKUP_REFS: |
-    insightsengineering/teal.data
-    insightsengineering/teal.slice
-    insightsengineering/teal.code
-    insightsengineering/teal.logger
-    insightsengineering/teal.reporter
-    insightsengineering/teal.widgets
-    insightsengineering/rtables
-    insightsengineering/rtables.officer
 
 jobs:
   audit:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,6 +16,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  env:
+    LOOKUP_REFS: |
+      insightsengineering/teal.data
+      insightsengineering/teal.slice
+      insightsengineering/teal.code
+      insightsengineering/teal.logger
+      insightsengineering/teal.reporter
+      insightsengineering/teal.widgets
+      insightsengineering/rtables
+      insightsengineering/rtables.officer
   audit:
     name: Audit Dependencies 🕵️‍♂️
     uses: insightsengineering/r.pkg.template/.github/workflows/audit.yaml@main
@@ -43,15 +53,8 @@ jobs:
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.code
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
+      lookup-refs: ${{ env.LOOKUP_REFS }}
+
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -74,15 +77,8 @@ jobs:
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.code
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
+      lookup-refs: ${{ env.LOOKUP_REFS }}
+
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -92,15 +88,7 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.code
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
+      lookup-refs: ${{ env.LOOKUP_REFS }}
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -113,15 +101,7 @@ jobs:
     with:
       auto-update: true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.code
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
+      lookup-refs: ${{ env.LOOKUP_REFS }}
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -50,6 +50,7 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
         insightsengineering/rtables.officer
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
@@ -80,6 +81,8 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -115,6 +118,8 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,3 +50,5 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   validation:
     name: R Package Validation report 📃
     needs: release
@@ -39,6 +41,8 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   release:
     name: Create release 🎉
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
@@ -71,6 +75,8 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   coverage:
     name: Coverage 📔
     needs: [release, docs]
@@ -88,6 +94,8 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   wasm:
     name: Build WASM packages 🧑‍🏭
     needs: release

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -18,17 +18,18 @@ on:
           - branch-cleanup
           - revdepcheck
 
+env:
+  LOOKUP_REFS: |
+    insightsengineering/teal.data
+    insightsengineering/teal.slice
+    insightsengineering/teal.code
+    insightsengineering/teal.logger
+    insightsengineering/teal.reporter
+    insightsengineering/teal.widgets
+    insightsengineering/rtables
+    insightsengineering/rtables.officer
+
 jobs:
-  env:
-    LOOKUP_REFS: |
-      insightsengineering/teal.data
-      insightsengineering/teal.slice
-      insightsengineering/teal.code
-      insightsengineering/teal.logger
-      insightsengineering/teal.reporter
-      insightsengineering/teal.widgets
-      insightsengineering/rtables
-      insightsengineering/rtables.officer
   dependency-test:
     if: >
       github.event_name == 'schedule' || (

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,6 +1,17 @@
 ---
 name: Scheduled 🕰️
 
+env:
+  LOOKUP_REFS: |
+    insightsengineering/teal.data
+    insightsengineering/teal.slice
+    insightsengineering/teal.code
+    insightsengineering/teal.logger
+    insightsengineering/teal.reporter
+    insightsengineering/teal.widgets
+    insightsengineering/rtables
+    insightsengineering/rtables.officer
+
 on:
   schedule:
     - cron: '45 3 * * 0'
@@ -17,17 +28,6 @@ on:
           - dependency-test
           - branch-cleanup
           - revdepcheck
-
-env:
-  LOOKUP_REFS: |
-    insightsengineering/teal.data
-    insightsengineering/teal.slice
-    insightsengineering/teal.code
-    insightsengineering/teal.logger
-    insightsengineering/teal.reporter
-    insightsengineering/teal.widgets
-    insightsengineering/rtables
-    insightsengineering/rtables.officer
 
 jobs:
   dependency-test:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -64,6 +64,7 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
         insightsengineering/rtables.officer
   rhub:
     if: >
@@ -81,3 +82,5 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -19,6 +19,16 @@ on:
           - revdepcheck
 
 jobs:
+  env:
+    LOOKUP_REFS: |
+      insightsengineering/teal.data
+      insightsengineering/teal.slice
+      insightsengineering/teal.code
+      insightsengineering/teal.logger
+      insightsengineering/teal.reporter
+      insightsengineering/teal.widgets
+      insightsengineering/rtables
+      insightsengineering/rtables.officer
   dependency-test:
     if: >
       github.event_name == 'schedule' || (
@@ -57,15 +67,7 @@ jobs:
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
     with:
-      lookup-refs: |
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.code
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
+      lookup-refs: ${{ env.LOOKUP_REFS }}
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -75,12 +77,4 @@ jobs:
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
     with:
-      lookup-refs: |
-        insightsengineering/teal.data
-        insightsengineering/teal.slice
-        insightsengineering/teal.code
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
+      lookup-refs: ${{ env.LOOKUP_REFS }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -64,6 +64,7 @@ jobs:
         insightsengineering/teal.logger
         insightsengineering/teal.reporter
         insightsengineering/teal.widgets
+        insightsengineering/rtables.officer
   rhub:
     if: >
       github.event_name == 'schedule' || (

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,17 +1,6 @@
 ---
 name: Scheduled 🕰️
 
-env:
-  LOOKUP_REFS: |
-    insightsengineering/teal.data
-    insightsengineering/teal.slice
-    insightsengineering/teal.code
-    insightsengineering/teal.logger
-    insightsengineering/teal.reporter
-    insightsengineering/teal.widgets
-    insightsengineering/rtables
-    insightsengineering/rtables.officer
-
 on:
   schedule:
     - cron: '45 3 * * 0'
@@ -68,7 +57,15 @@ jobs:
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
     with:
-      lookup-refs: ${{ env.LOOKUP_REFS }}
+      lookup-refs: |
+        insightsengineering/teal.data
+        insightsengineering/teal.slice
+        insightsengineering/teal.code
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -78,4 +75,12 @@ jobs:
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
     with:
-      lookup-refs: ${{ env.LOOKUP_REFS }}
+      lookup-refs: |
+        insightsengineering/teal.data
+        insightsengineering/teal.slice
+        insightsengineering/teal.code
+        insightsengineering/teal.logger
+        insightsengineering/teal.reporter
+        insightsengineering/teal.widgets
+        insightsengineering/rtables
+        insightsengineering/rtables.officer

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -1481,19 +1481,19 @@ testthat::describe("srv_teal filters", {
           # mtcars has been modified
           expected_mtcars <- subset(mtcars, cyl == 4)
           testthat::expect_identical(modules_output$module_1()()[["mtcars"]], expected_mtcars)
-          expected_code <- c(
-            "iris <- iris",
-            "mtcars <- mtcars",
-            sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
-            sprintf('stopifnot(rlang::hash(mtcars) == "%s") # @linksto mtcars', rlang::hash(mtcars)),
-            ".raw_data <- list2env(list(iris = iris, mtcars = mtcars))",
-            "lockEnvironment(.raw_data) # @linksto .raw_data",
-            "mtcars <- dplyr::filter(mtcars, cyl == 4)"
+          expected_code <- paste0(
+            c(
+              "iris <- iris",
+              "mtcars <- mtcars",
+              sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
+              sprintf('stopifnot(rlang::hash(mtcars) == "%s") # @linksto mtcars', rlang::hash(mtcars)),
+              ".raw_data <- list2env(list(iris = iris, mtcars = mtcars))",
+              "lockEnvironment(.raw_data) # @linksto .raw_data",
+              "mtcars <- dplyr::filter(mtcars, cyl == 4)"
+            ),
+            collapse = "\n"
           )
-          testthat::expect_setequal(
-            strsplit(teal.code::get_code(modules_output$module_1()()), "\n")[[1]],
-            expected_code
-          )
+          testthat::expect_identical(teal.code::get_code(modules_output$module_1()()), expected_code)
         }
       )
     })
@@ -1660,7 +1660,7 @@ testthat::describe("srv_teal teal_module(s) transformer", {
         expected_iris <- head(expected_iris)
         testthat::expect_identical(modules_output$module_1()()[["iris"]], expected_iris)
         testthat::expect_identical(modules_output$module_1()()[["mtcars"]], head(subset(mtcars, cyl == 6)))
-        expected_code <- c(
+        expected_code <- paste(collapse = "\n", c(
           "iris <- iris",
           "mtcars <- mtcars",
           sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
@@ -1671,9 +1671,9 @@ testthat::describe("srv_teal teal_module(s) transformer", {
           "mtcars <- dplyr::filter(mtcars, cyl == 6)",
           "iris <- head(iris, n = 6)",
           "mtcars <- head(mtcars, n = 6)"
-        )
-        testthat::expect_setequal(
-          strsplit(teal.code::get_code(modules_output$module_1()()), "\n")[[1]],
+        ))
+        testthat::expect_identical(
+          teal.code::get_code(modules_output$module_1()()),
           expected_code
         )
       }
@@ -1706,7 +1706,7 @@ testthat::describe("srv_teal teal_module(s) transformer", {
 
         testthat::expect_identical(modules_output$module_1()()[["iris"]], head(iris))
         testthat::expect_identical(modules_output$module_1()()[["mtcars"]], head(subset(mtcars, cyl == 4)))
-        expected_code <- c(
+        expected_code <- paste(collapse = "\n", c(
           "iris <- iris",
           "mtcars <- mtcars",
           sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
@@ -1716,9 +1716,9 @@ testthat::describe("srv_teal teal_module(s) transformer", {
           "mtcars <- dplyr::filter(mtcars, cyl == 4)",
           "iris <- head(iris, n = 6)",
           "mtcars <- head(mtcars, n = 6)"
-        )
-        testthat::expect_setequal(
-          strsplit(teal.code::get_code(modules_output$module_1()()), "\n")[[1]],
+        ))
+        testthat::expect_identical(
+          teal.code::get_code(modules_output$module_1()()),
           expected_code
         )
       }

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -1481,19 +1481,19 @@ testthat::describe("srv_teal filters", {
           # mtcars has been modified
           expected_mtcars <- subset(mtcars, cyl == 4)
           testthat::expect_identical(modules_output$module_1()()[["mtcars"]], expected_mtcars)
-          expected_code <- paste0(
-            c(
-              "iris <- iris",
-              "mtcars <- mtcars",
-              sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
-              sprintf('stopifnot(rlang::hash(mtcars) == "%s") # @linksto mtcars', rlang::hash(mtcars)),
-              ".raw_data <- list2env(list(iris = iris, mtcars = mtcars))",
-              "lockEnvironment(.raw_data) # @linksto .raw_data",
-              "mtcars <- dplyr::filter(mtcars, cyl == 4)"
-            ),
-            collapse = "\n"
+          expected_code <- c(
+            "iris <- iris",
+            "mtcars <- mtcars",
+            sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
+            sprintf('stopifnot(rlang::hash(mtcars) == "%s") # @linksto mtcars', rlang::hash(mtcars)),
+            ".raw_data <- list2env(list(iris = iris, mtcars = mtcars))",
+            "lockEnvironment(.raw_data) # @linksto .raw_data",
+            "mtcars <- dplyr::filter(mtcars, cyl == 4)"
           )
-          testthat::expect_identical(teal.code::get_code(modules_output$module_1()()), expected_code)
+          testthat::expect_setequal(
+            strsplit(teal.code::get_code(modules_output$module_1()()), "\n")[[1]],
+            expected_code
+          )
         }
       )
     })
@@ -1660,7 +1660,7 @@ testthat::describe("srv_teal teal_module(s) transformer", {
         expected_iris <- head(expected_iris)
         testthat::expect_identical(modules_output$module_1()()[["iris"]], expected_iris)
         testthat::expect_identical(modules_output$module_1()()[["mtcars"]], head(subset(mtcars, cyl == 6)))
-        expected_code <- paste(collapse = "\n", c(
+        expected_code <- c(
           "iris <- iris",
           "mtcars <- mtcars",
           sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
@@ -1671,9 +1671,9 @@ testthat::describe("srv_teal teal_module(s) transformer", {
           "mtcars <- dplyr::filter(mtcars, cyl == 6)",
           "iris <- head(iris, n = 6)",
           "mtcars <- head(mtcars, n = 6)"
-        ))
-        testthat::expect_identical(
-          teal.code::get_code(modules_output$module_1()()),
+        )
+        testthat::expect_setequal(
+          strsplit(teal.code::get_code(modules_output$module_1()()), "\n")[[1]],
           expected_code
         )
       }
@@ -1706,7 +1706,7 @@ testthat::describe("srv_teal teal_module(s) transformer", {
 
         testthat::expect_identical(modules_output$module_1()()[["iris"]], head(iris))
         testthat::expect_identical(modules_output$module_1()()[["mtcars"]], head(subset(mtcars, cyl == 4)))
-        expected_code <- paste(collapse = "\n", c(
+        expected_code <- c(
           "iris <- iris",
           "mtcars <- mtcars",
           sprintf('stopifnot(rlang::hash(iris) == "%s") # @linksto iris', rlang::hash(iris)),
@@ -1716,9 +1716,9 @@ testthat::describe("srv_teal teal_module(s) transformer", {
           "mtcars <- dplyr::filter(mtcars, cyl == 4)",
           "iris <- head(iris, n = 6)",
           "mtcars <- head(mtcars, n = 6)"
-        ))
-        testthat::expect_identical(
-          teal.code::get_code(modules_output$module_1()()),
+        )
+        testthat::expect_setequal(
+          strsplit(teal.code::get_code(modules_output$module_1()()), "\n")[[1]],
           expected_code
         )
       }


### PR DESCRIPTION
Workflows are failing on main and on every PR as `rtables.officer` is not yet released on CRAN. 

`rtables.officer` is an indirect dependency via `teal.reporter`.

### Changes description

- Adds rtables and rtables.officer to `lookup-refs` on `setup-r-dependencies` workflow