### PR TITLE
negative datanames selection

### DIFF
--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -347,8 +347,8 @@ srv_teal_module.teal_module <- function(id,
 
 .resolve_module_datanames <- function(data, modules) {
   stopifnot("data_rv must be teal_data object." = inherits(data, "teal_data"))
-  if (is.null(modules$datanames) || identical(modules$datanames, "all")) {
-    names(data)
+  if (is.null(modules$datanames) || setequal(modules$datanames, "all")) {
+    setdiff(names(data), attr(modules$datanames, "excluded"))
   } else {
     intersect(
       names(data), # Keep topological order from teal.data::names()

--- a/R/modules.R
+++ b/R/modules.R
@@ -610,7 +610,13 @@ set_datanames <- function(modules, datanames) {
     modules$children <- lapply(modules$children, set_datanames, datanames)
   } else {
     if (identical(modules$datanames, "all")) {
-      modules$datanames <- datanames
+      included <- grep("^[^-]", datanames, value = TRUE)
+      if (length(included)) {
+        modules$datanames <- included
+      } else {
+        excluded <- gsub("^-", "", grep("^-", datanames, value = TRUE))
+        attr(modules$datanames, "excluded") <- excluded
+      }
     } else {
       warning(
         "Not possible to modify datanames of the module ", modules$label,


### PR DESCRIPTION
closes #1380 

Feature `set_datanames` has a limited effect because of the fact that modules can have `$datanames` slot set to names which are absolutely crucial for module to work. This is why we allow using `set_datanames` when `$datanames == "all"`. Adding "negative selection" will also have limited effect for the same reason but the code complication seems big enough to not recommend this feature.


```r
pkgload::load_all("teal")

trans <- list(
  anl_w_datanames = teal_transform_module(
    label = "ANL with datanames",
    ui = function(id) {
      ns <- NS(id)
      tagList(
        div("This transformer adds ANL based on specified ADSL, ADTTE"),
        numericInput(ns("obs"), "Number of subjects", value = 400, min = 0, max = 400)
      )
    },
    server = function(id, data) {
      moduleServer(id, function(input, output, session) {
        reactive({
          within(data(),
            {
              ANL <- dplyr::inner_join(
                head(ADSL, nobs),
                ADTTE[c("STUDYID", "USUBJID", setdiff(colnames(ADTTE), colnames(ADSL)))],
                by = c("USUBJID", "STUDYID")
              )
            },
            nobs = input$obs
          )
        })
      })
    },
    datanames = "ADTTE"
  ),
  anl_wout_datanames = teal_transform_module(
    label = "ANL without datanames",
    ui = function(id) {
      ns <- NS(id)
      tagList(
        div("This transformer adds ANL based on unspecified ADSL, ADTTE"),
        numericInput(ns("obs"), "Number of subjects", value = 400, min = 0, max = 400)
      )
    },
    server = function(id, data) {
      moduleServer(id, function(input, output, session) {
        reactive({
          within(data(),
            {
              ANL <- dplyr::inner_join(
                head(ADSL, nobs),
                ADTTE[c("STUDYID", "USUBJID", setdiff(colnames(ADTTE), colnames(ADSL)))],
                by = c("USUBJID", "STUDYID")
              )
            },
            nobs = input$obs
          )
        })
      })
    }
  ),
  adsl_w_datanames = teal_transform_module(
    label = "modify ADSL",
    ui = function(id) {
      ns <- NS(id)
      tagList(
        div("This transformer modifies ADSL based on specified ADTTE")
      )
    },
    server = function(id, data) {
      moduleServer(id, function(input, output, session) {
        reactive({
          within(data(),
            {
              ADTTE_summary <- ADTTE |>
                dplyr::group_by(STUDYID, USUBJID) |>
                dplyr::summarize(PARAMCD_AVAL = paste(paste(PARAMCD, "-", AVAL), collapse = "; "))
              ADSL <- dplyr::left_join(ADSL, ADTTE_summary)
            },
            nobs = input$obs
          )
        })
      })
    },
    datanames = c("ADSL", "ADTTE")
  ),
  adsl_wout_datanames = teal_transform_module(
    label = "modify ADSL",
    ui = function(id) {
      ns <- NS(id)
      tagList(
        div("This transformer modifies ADSL based on unspecified ADTTE")
      )
    },
    server = function(id, data) {
      moduleServer(id, function(input, output, session) {
        reactive({
          within(data(),
            {
              ADTTE_summary <- ADTTE |>
                dplyr::group_by(STUDYID, USUBJID) |>
                dplyr::summarize(PARAMCD_AVAL = paste(sprintf("%s - %.2f", PARAMCD, AVAL), collapse = "; "))
              ADSL <- dplyr::left_join(ADSL, ADTTE_summary)
            },
            nobs = input$obs
          )
        })
      })
    },
    datanames = "ADSL"
  )
)

data <- teal_data_module(
  once = FALSE,
  ui = function(id) {
    ns <- NS(id)
    tagList(
      numericInput(ns("obs"), "Number of observations to show", 1000),
      actionButton(ns("submit"), label = "Submit")
    )
  },
  server = function(id, ...) {
    moduleServer(id, function(input, output, session) {
      logger::log_trace("example_module_transform2 initializing.")
      eventReactive(input$submit, {
        data <- teal_data(a = NULL) |>
          within(
            {
              logger::log_trace("Loading data")
              ADSL <- head(teal.data::rADSL, n = n)
              ADTTE <- teal.data::rADTTE
              iris <- iris
              .iris_raw <- iris
              CO2 <- CO2
              factors <- names(Filter(isTRUE, vapply(CO2, is.factor, logical(1L))))
              CO2[factors] <- lapply(CO2[factors], as.character)
            },
            n = as.numeric(input$obs)
          )
        join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
        data
      })
    })
  }
)

app <- teal::init(
  data = data,
  modules = modules(
    example_module("all", datanames = "all"),
    example_module("null", datanames = NULL),
    example_module("adtte", datanames = "ADTTE"),
    example_module("adsl", datanames = "ADSL"),
    example_module("adsl+adtte", datanames = c("ADSL", "ADTTE")),
    example_module("inexisting+existing", datanames = c("ADTTE", "inexisting")),
    example_module("anl - transform w/ datanames", dataname = "ANL", transformators = trans["anl_w_datanames"]),
    example_module("anl - transform w/o datanames", dataname = "ANL", transformators = trans["anl_wout_datanames"]),
    example_module("adsl - transform w/ datanames", dataname = "ADSL", transformators = trans["adsl_w_datanames"]),
    example_module("adsl - transform w/o datanames", dataname = "ADSL", transformators = trans["adsl_wout_datanames"]),
    example_module("inexisting", datanames = "inexisting"),
    reporter_previewer_module()
  ) |> set_datanames("-ADTTE"),
  filter = teal_slices(
    teal_slice("ADSL", "SEX"),
    teal_slice("ADSL", "AGE", selected = c(18L, 65L)),
    teal_slice("ADTTE", "PARAMCD", selected = "CRSD"),
    include_varnames = list(
      ADSL = c("SEX", "AGE")
    )
  )
)

runApp(app)
```