### PR TITLE
Fixes broken links by leveraging `pkgdown` autodetection of function use in inline code

### DIFF
--- a/vignettes/data-transform-as-shiny-module.Rmd
+++ b/vignettes/data-transform-as-shiny-module.Rmd
@@ -12,10 +12,10 @@ vignette: >
 
 ## Introduction
 
-[`teal_transform_module()`](https://insightsengineering.github.io/teal/latest-tag/reference/teal_transform_module.html) is a Shiny module that takes `ui` and `server` arguments. When provided, `teal` will execute data transformations for the specified module when it is loaded and whenever the data changes. `server` extend the logic behind data manipulations, where `ui` extends filter panel with new UI elements that orchestrate the transformator inputs.
+`teal_transform_module()` is a Shiny module that takes `ui` and `server` arguments. When provided, `teal` will execute data transformations for the specified module when it is loaded and whenever the data changes. `server` extend the logic behind data manipulations, where `ui` extends filter panel with new UI elements that orchestrate the transformator inputs.
 
 `teal` version `0.16` introduced a new, optional argument in `teal::module` named `transformators`. 
-This argument allows to pass a `list` of `"teal_data_module"` class of objects created using [`teal_transform_module()`](https://insightsengineering.github.io/teal/latest-tag/reference/teal_transform_module.html) function.
+This argument allows to pass a `list` of `"teal_data_module"` class of objects created using `teal_transform_module()` function.
 
 The main benefit of `teal_transform_module()` is the ability to transform data before passing it 
 to the module. This feature allows to extend the regular behavior of existing modules by specifying custom data operations on data inside this module.

--- a/vignettes/decorate-module-output.Rmd
+++ b/vignettes/decorate-module-output.Rmd
@@ -79,7 +79,7 @@ static_decorator <- teal_transform_module(
 
 To simplify the repetitive elements of writing new decorators 
 (e.g., `function(id, data), moduleServer, reactive, within(data, ...)`), 
-you can use the `make_teal_transform_server()`] convenience function, which takes a `language` as input:
+you can use the `make_teal_transform_server()` convenience function, which takes a `language` as input:
 
 ```{r}
 static_decorator_lang <- teal_transform_module(

--- a/vignettes/decorate-module-output.Rmd
+++ b/vignettes/decorate-module-output.Rmd
@@ -14,7 +14,7 @@ vignette: >
 
 `teal` is a powerful `shiny`-based framework with built-in modules for interactive data analysis. 
 This document outlines the customization options available for modifying the output of `teal` modules. 
-You will learn how to use [`teal_transform_module`](https://insightsengineering.github.io/teal/latest-tag/reference/teal_transform_module.html) to modify and enhance the objects created by `teal::modules()`, 
+You will learn how to use `teal_transform_module()` to modify and enhance the objects created by `teal::modules()`, 
 enabling you to tailor the outputs to your specific requirements without rewriting the original module code.
 
 ## Decorators
@@ -48,12 +48,12 @@ created through `teal_transform_module`.
 
 In below chapter we will present how to create the simplest static decorator with just a server part. Later, we will
 present examples on more advanced usage, where decorators contain UI. You will also learn about a convenience 
-function that makes it easier to write decorators, called [`make_teal_transform_server`](https://insightsengineering.github.io/teal/latest-tagx/reference/make_teal_transform_server.html). The chapter ends with an 
+function that makes it easier to write decorators, called `make_teal_transform_server()`. The chapter ends with an 
 example module that utilizes decorators and a snippet that uses this module in `teal` application.
 
 ### Server
 
-The simplest way to create a decorator is to use [`teal_transform_module`](https://insightsengineering.github.io/teal/latest-tag/reference/teal_transform_module.html) with only `server` argument provided (i.e. without UI part).
+The simplest way to create a decorator is to use `teal_transform_module()` with only `server` argument provided (i.e. without UI part).
 This approach adds functionality solely to the server code of the module. 
 In the following example, we assume that the module contains an object (of class `ggplot2`) named `plot`. 
 We modify the title and x-axis label of plot:
@@ -79,7 +79,7 @@ static_decorator <- teal_transform_module(
 
 To simplify the repetitive elements of writing new decorators 
 (e.g., `function(id, data), moduleServer, reactive, within(data, ...)`), 
-you can use the [`make_teal_transform_server()`](https://insightsengineering.github.io/teal/latest-tag/reference/make_teal_transform_server.html) convenience function, which takes a `language` as input:
+you can use the `make_teal_transform_server()`] convenience function, which takes a `language` as input:
 
 ```{r}
 static_decorator_lang <- teal_transform_module(
@@ -98,7 +98,7 @@ static_decorator_lang <- teal_transform_module(
 
 To create a decorator with user interactivity, you can add (optional) UI part and use it in server accordingly (i.e. a typical `shiny` module). 
 In the example below, the x-axis title is set dynamically via a `textInput`, allowing users to specify their preferred label. 
-Note how the input parameters are passed to the [`within`](https://insightsengineering.github.io/teal/latest-tag/reference/teal_data_module.html) function using its `...` argument.
+Note how the input parameters are passed to the `within()` function using its `...` argument.
 
 ```{r}
 interactive_decorator <- teal_transform_module(
@@ -127,7 +127,7 @@ interactive_decorator <- teal_transform_module(
 )
 ```
 
-As in the earlier examples, [`make_teal_transform_server()`](https://insightsengineering.github.io/teal/latest-tag/reference/make_teal_transform_server.html) can simplify the creation of the server component. 
+As in the earlier examples, `make_teal_transform_server()` can simplify the creation of the server component. 
 This wrapper requires you to use `input` object names directly in the expression - note that we have `xlab(x_axis_table)` and not `my_title = input$x_axis_title` together with `xlab(my_title)`.
 
 ```{r}


### PR DESCRIPTION
#### Changes description

- Change absolute paths to `insightsengineering.github.io/teal/...` to `fun_name()`
    - downside:
        - `knitr` keeps the inline code as is, so CRAN's vignettes don't have the links
    - upside:
        - pkgdown is smart to detect and create a link to the reference page (see within)
        - `urlcheck` CI doesn't fail on `main` and PRs with unreleased code
        - Articles in version-specific documentation don't suddenly take you to `latest-tag`

#### Alternatives considered

Using relative links (`../reference`), but this will break CRAN vignettes as well