### PR TITLE
deprecate id from init

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### New features
 
 * Possible to call `ui_teal` and `srv_teal` directly in any application by delivering `data` argument as a `reactive` returning `teal_data` object. #669
+* Since introduction of `ui_teal` and `srv_teal` functions `id` argument in `init` is being deprecated. #1438
 * Introduced `teal_transform_module` to provide a way to interactively modify data delivered to `teal_module`'s `server` and to decorate module outputs. #1228 #1384
 * Introduced a new argument `once = FALSE` in `teal_data_module` to possibly reload data during a run time.
 * Possibility to download lockfile to restore app session for reproducibility. #479

--- a/R/init.R
+++ b/R/init.R
@@ -27,9 +27,11 @@
 #'   the header of the app.
 #' @param footer (`shiny.tag` or `character(1)`) Optionally,
 #'   the footer of the app.
-#' @param id (`character`) Optionally,
+#' @param id `r lifecycle::badge("deprecated")` (`character`) Optionally,
 #'   a string specifying the `shiny` module id in cases it is used as a `shiny` module
-#'   rather than a standalone `shiny` app. This is a legacy feature.
+#'   rather than a standalone `shiny` app. This is a legacy feature. Deprecated since v0.15.3
+#'   please use [ui_teal()] and [srv_teal()] instead.
+#'
 #' @param landing_popup (`teal_module_landing`) Optionally,
 #'   a `landing_popup_module` to show up as soon as the teal app is initialized.
 #'
@@ -96,7 +98,7 @@ init <- function(data,
                  title = build_app_title(),
                  header = tags$p(),
                  footer = tags$p(),
-                 id = character(0),
+                 id = lifecycle::deprecated(),
                  landing_popup = NULL) {
   logger::log_debug("init initializing teal app with: data ('{ class(data) }').")
 
@@ -137,7 +139,6 @@ init <- function(data,
     checkmate::check_string(footer),
     checkmate::check_multi_class(footer, c("shiny.tag", "shiny.tag.list", "html"))
   )
-  checkmate::assert_character(id, max.len = 1, any.missing = FALSE)
 
   # log
   teal.logger::log_system_info()
@@ -221,6 +222,20 @@ init <- function(data,
     )
   }
 
+
+  if (lifecycle::is_present(id)) {
+    lifecycle::deprecate_soft(
+      when = "0.15.3",
+      what = "init(id)",
+      details = paste(
+        "To wrap `teal` application within other shiny application please use",
+        "`ui_teal()` and `srv_teal()` and call them as normal shiny modules"
+      )
+    )
+    checkmate::assert_character(id, max.len = 1, any.missing = FALSE)
+  } else {
+    id <- character(0)
+  }
   ns <- NS(id)
   # Note: UI must be a function to support bookmarking.
   res <- list(

--- a/R/init.R
+++ b/R/init.R
@@ -229,7 +229,7 @@ init <- function(data,
       what = "init(id)",
       details = paste(
         "To wrap `teal` application within other shiny application please use",
-        "`ui_teal()` and `srv_teal()` and call them as normal shiny modules"
+        "`ui_teal()` and `srv_teal()` and call them as regular shiny modules."
       )
     )
     checkmate::assert_character(id, max.len = 1, any.missing = FALSE)

--- a/R/module_bookmark_manager.R
+++ b/R/module_bookmark_manager.R
@@ -29,7 +29,7 @@
 #' - set `options(shiny.bookmarkStore = "server")` before running the app
 #'
 #'
-#' @inheritParams init
+#' @inheritParams module_teal
 #'
 #' @return Invisible `NULL`.
 #'

--- a/R/module_data_summary.R
+++ b/R/module_data_summary.R
@@ -12,8 +12,7 @@
 #' Module includes also "Show/Hide unsupported" button to toggle rows of the summary table
 #' containing datasets where number of observations are not calculated.
 #'
-#' @param id (`character(1)`) `shiny` module instance id.
-#' @param teal_data (`reactive` returning `teal_data`)
+#' @inheritParams module_teal_module
 #'
 #' @name module_data_summary
 #' @rdname module_data_summary

--- a/R/module_init_data.R
+++ b/R/module_init_data.R
@@ -22,10 +22,7 @@
 #'
 #' For more details, see [`module_teal_data`].
 #'
-#' @inheritParams init
-#'
-#' @param data (`teal_data`, `teal_data_module`, or `reactive` returning `teal_data`)
-#' The data which application will depend on.
+#' @inheritParams module_teal
 #'
 #' @return A `reactive` object that returns:
 #' Output of the `data`. If `data` fails then returned error is handled (after [tryCatch()]) so that

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -32,8 +32,10 @@
 #' @rdname module_teal
 #' @name module_teal
 #'
-#' @inheritParams module_init_data
 #' @inheritParams init
+#' @param id (`character(1)`) `shiny` module instance id.
+#' @param data (`teal_data`, `teal_data_module`, or `reactive` returning `teal_data`)
+#' The data which application will depend on.
 #'
 #' @return `NULL` invisibly
 NULL

--- a/R/module_teal_data.R
+++ b/R/module_teal_data.R
@@ -20,8 +20,7 @@
 #' resolved, the app will continue to run. `teal` guarantees that errors in data don't crash the app
 #' (except error 1).
 #'
-#' @param id (`character(1)`) Module id
-#' @param data (`reactive teal_data`)
+#' @inheritParams module_teal_module
 #' @param data_module (`teal_data_module`)
 #' @param modules (`teal_modules` or `teal_module`) For `datanames` validation purpose
 #' @param validate_shiny_silent_error (`logical`) If `TRUE`, then `shiny.silent.error` is validated and

--- a/R/module_teal_lockfile.R
+++ b/R/module_teal_lockfile.R
@@ -1,5 +1,6 @@
 #' Generate lockfile for application's environment reproducibility
 #'
+#' @inheritParams module_teal
 #' @param lockfile_path (`character`) path to the lockfile.
 #'
 #' @section Different ways of creating lockfile:

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -11,7 +11,7 @@ init(
   title = build_app_title(),
   header = tags$p(),
   footer = tags$p(),
-  id = character(0),
+  id = lifecycle::deprecated(),
   landing_popup = NULL
 )
 }
@@ -39,9 +39,10 @@ the header of the app.}
 \item{footer}{(\code{shiny.tag} or \code{character(1)}) Optionally,
 the footer of the app.}
 
-\item{id}{(\code{character}) Optionally,
+\item{id}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} (\code{character}) Optionally,
 a string specifying the \code{shiny} module id in cases it is used as a \code{shiny} module
-rather than a standalone \code{shiny} app. This is a legacy feature.}
+rather than a standalone \code{shiny} app. This is a legacy feature. Deprecated since v0.15.3
+please use \code{\link[=ui_teal]{ui_teal()}} and \code{\link[=srv_teal]{srv_teal()}} instead.}
 
 \item{landing_popup}{(\code{teal_module_landing}) Optionally,
 a \code{landing_popup_module} to show up as soon as the teal app is initialized.}

--- a/man/module_bookmark_manager.Rd
+++ b/man/module_bookmark_manager.Rd
@@ -20,9 +20,7 @@ get_bookmarking_option()
 need_bookmarking(modules)
 }
 \arguments{
-\item{id}{(\code{character}) Optionally,
-a string specifying the \code{shiny} module id in cases it is used as a \code{shiny} module
-rather than a standalone \code{shiny} app. This is a legacy feature.}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{modules}{(\code{list} or \code{teal_modules} or \code{teal_module})
 Nested list of \code{teal_modules} or \code{teal_module} objects or a single

--- a/man/module_data_summary.Rd
+++ b/man/module_data_summary.Rd
@@ -25,7 +25,7 @@ get_filter_overview_MultiAssayExperiment(current_data, initial_data, dataname)
 \arguments{
 \item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
-\item{teal_data}{(\code{reactive} returning \code{teal_data})}
+\item{data}{(\code{reactive} returning \code{teal_data})}
 
 \item{current_data}{(\code{object}) current object (after filtering and transforming).}
 

--- a/man/module_filter_data.Rd
+++ b/man/module_filter_data.Rd
@@ -20,9 +20,7 @@ srv_filter_data(id, datasets, active_datanames, data, is_active)
 .get_filter_expr(datasets, datanames)
 }
 \arguments{
-\item{id}{(\code{character}) Optionally,
-a string specifying the \code{shiny} module id in cases it is used as a \code{shiny} module
-rather than a standalone \code{shiny} app. This is a legacy feature.}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{datasets}{(\code{reactive} returning \code{FilteredData} or \code{NULL})
 When \code{datasets} is passed from the parent module (\code{srv_teal}) then \code{dataset} is a singleton

--- a/man/module_init_data.Rd
+++ b/man/module_init_data.Rd
@@ -11,9 +11,7 @@ ui_init_data(id)
 srv_init_data(id, data)
 }
 \arguments{
-\item{id}{(\code{character}) Optionally,
-a string specifying the \code{shiny} module id in cases it is used as a \code{shiny} module
-rather than a standalone \code{shiny} app. This is a legacy feature.}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{data}{(\code{teal_data}, \code{teal_data_module}, or \code{reactive} returning \code{teal_data})
 The data which application will depend on.}

--- a/man/module_teal.Rd
+++ b/man/module_teal.Rd
@@ -17,9 +17,7 @@ ui_teal(
 srv_teal(id, data, modules, filter = teal_slices())
 }
 \arguments{
-\item{id}{(\code{character}) Optionally,
-a string specifying the \code{shiny} module id in cases it is used as a \code{shiny} module
-rather than a standalone \code{shiny} app. This is a legacy feature.}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{modules}{(\code{list} or \code{teal_modules} or \code{teal_module})
 Nested list of \code{teal_modules} or \code{teal_module} objects or a single

--- a/man/module_teal_data.Rd
+++ b/man/module_teal_data.Rd
@@ -31,7 +31,7 @@ srv_validate_reactive_teal_data(
 )
 }
 \arguments{
-\item{id}{(\code{character(1)}) Module id}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{data_module}{(\code{teal_data_module})}
 
@@ -43,7 +43,7 @@ srv_validate_reactive_teal_data(
 Help to determine if any previous transformator failed, so that following transformators can be disabled
 and display a generic failure message.}
 
-\item{data}{(\verb{reactive teal_data})}
+\item{data}{(\code{reactive} returning \code{teal_data})}
 }
 \value{
 \code{reactive} \code{teal_data}

--- a/man/module_teal_lockfile.Rd
+++ b/man/module_teal_lockfile.Rd
@@ -23,6 +23,8 @@ srv_teal_lockfile(id)
 .is_disabled_lockfile_scenario()
 }
 \arguments{
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
+
 \item{lockfile_path}{(\code{character}) path to the lockfile.}
 }
 \value{

--- a/man/module_teal_module.Rd
+++ b/man/module_teal_module.Rd
@@ -65,9 +65,7 @@ srv_teal_module(
 )
 }
 \arguments{
-\item{id}{(\code{character}) Optionally,
-a string specifying the \code{shiny} module id in cases it is used as a \code{shiny} module
-rather than a standalone \code{shiny} app. This is a legacy feature.}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{modules}{(\code{list} or \code{teal_modules} or \code{teal_module})
 Nested list of \code{teal_modules} or \code{teal_module} objects or a single

--- a/man/module_teal_with_splash.Rd
+++ b/man/module_teal_with_splash.Rd
@@ -17,9 +17,7 @@ ui_teal_with_splash(
 srv_teal_with_splash(id, data, modules, filter = teal_slices())
 }
 \arguments{
-\item{id}{(\code{character}) Optionally,
-a string specifying the \code{shiny} module id in cases it is used as a \code{shiny} module
-rather than a standalone \code{shiny} app. This is a legacy feature.}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{data}{(\code{teal_data}, \code{teal_data_module}, or \code{reactive} returning \code{teal_data})
 The data which application will depend on.}

--- a/man/module_transform_data.Rd
+++ b/man/module_transform_data.Rd
@@ -17,13 +17,13 @@ srv_transform_teal_data(
 )
 }
 \arguments{
-\item{id}{(\code{character(1)}) Module id}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
 \item{transformators}{(\code{list} of \code{teal_transform_module}) that will be applied to transformator module's data input.}
 
 \item{class}{(character(1)) CSS class to be added in the \code{div} wrapper tag.}
 
-\item{data}{(\verb{reactive teal_data})}
+\item{data}{(\code{reactive} returning \code{teal_data})}
 
 \item{modules}{(\code{teal_modules} or \code{teal_module}) For \code{datanames} validation purpose}
 


### PR DESCRIPTION
- deprecate id in init #1438  
- fixing (wrong) id documentation in inherited docs. Please notice that methods were inheriting `id` documentation from init. It means that all modules had a wrong description.

