### PR TITLE
runApp can't work due to as.shinyapp.obj dispatch failure

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -243,7 +243,7 @@ init <- function(data,
         srv_session_info("teal-footer-session_info")
       }
     ),
-    class = "teal_app"
+    class = c("teal_app", "list")
   )
 
   if (lifecycle::is_present(title)) {


### PR DESCRIPTION
Run this to see what happens

```r
library(teal.modules.general)

app <- teal::init(
  data = teal_data() |> within(iris <- iris),
  modules = modules(
    tm_missing_data()
  )
)

runApp(app)
```