### PR TITLE
Update teal.reporter version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Imports:
     stats,
     teal.code (>= 0.5.0.9022),
     teal.logger (>= 0.3.1),
-    teal.reporter (>= 0.3.1.9023),
+    teal.reporter (>= 0.4.0),
     teal.widgets (>= 0.4.0),
     tools,
     utils
@@ -79,7 +79,6 @@ RdMacros:
 Remotes:
     insightsengineering/teal.code,
     insightsengineering/teal.data,
-    insightsengineering/teal.reporter,
     insightsengineering/teal.slice
 Config/Needs/verdepcheck: rstudio/shiny, insightsengineering/teal.data,
     insightsengineering/teal.slice, mllg/checkmate, jeroen/jsonlite,


### PR DESCRIPTION
Since new version of teal.reporter is on CRAN
it's a good moment to update teal, the reverse dependency,
so that we can run tests and see if all is passing for the newly released teal.repoter.

teal will be released anyway soon and dependencies would be bumped to releases versions
https://cran.r-project.org/web/packages/teal.reporter/index.html