### PR TITLE
Move the reporter module creation to `module_teal`

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -178,14 +178,6 @@ init <- function(data,
     }
   }
 
-  reporter <- teal.reporter::Reporter$new()$set_id(attr(filter, "app_id"))
-  if (is_arg_used(modules, "reporter") && length(extract_module(modules, "teal_module_previewer")) == 0) {
-    modules <- append_module(
-      modules,
-      reporter_previewer_module(server_args = list(previewer_buttons = c("download", "reset")))
-    )
-  }
-
   # argument transformations
   ## `modules` - landing module
   landing <- extract_module(modules, "teal_module_landing")

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -46,20 +46,6 @@
 NULL
 
 #' @rdname module_teal
-#' @keywords internal
-#' @noRd
-append_reporter_module <- function(modules) {
-  reporter <- teal.reporter::Reporter$new()$set_id(attr(filter, "app_id"))
-  if (is_arg_used(modules, "reporter") && length(extract_module(modules, "teal_module_previewer")) == 0) {
-    modules <- append_module(
-      modules,
-      reporter_previewer_module(server_args = list(previewer_buttons = c("download", "reset")))
-    )
-  }
-  modules
-}
-
-#' @rdname module_teal
 #' @export
 ui_teal <- function(id, modules) {
   checkmate::assert_character(id, max.len = 1, any.missing = FALSE)
@@ -236,6 +222,7 @@ srv_teal <- function(id, data, modules, filter = teal_slices()) {
       )
     }
 
+    reporter <- teal.reporter::Reporter$new()$set_id(attr(filter, "app_id"))
     module_labels <- unlist(module_labels(modules), use.names = FALSE)
     slices_global <- methods::new(".slicesGlobal", filter, module_labels)
     modules_output <- srv_teal_module(
@@ -244,7 +231,8 @@ srv_teal <- function(id, data, modules, filter = teal_slices()) {
       datasets = datasets_rv,
       modules = modules,
       slices_global = slices_global,
-      data_load_status = data_load_status
+      data_load_status = data_load_status,
+      reporter = reporter
     )
     mapping_table <- srv_filter_manager_panel("filter_manager_panel", slices_global = slices_global)
     snapshots <- srv_snapshot_manager_panel("snapshot_manager_panel", slices_global = slices_global)

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -46,11 +46,27 @@
 NULL
 
 #' @rdname module_teal
+#' @keywords internal
+#' @noRd
+append_reporter_module <- function(modules) {
+  reporter <- teal.reporter::Reporter$new()$set_id(attr(filter, "app_id"))
+  if (is_arg_used(modules, "reporter") && length(extract_module(modules, "teal_module_previewer")) == 0) {
+    modules <- append_module(
+      modules,
+      reporter_previewer_module(server_args = list(previewer_buttons = c("download", "reset")))
+    )
+  }
+  modules
+}
+
+#' @rdname module_teal
 #' @export
 ui_teal <- function(id, modules) {
   checkmate::assert_character(id, max.len = 1, any.missing = FALSE)
   checkmate::assert_class(modules, "teal_modules")
   ns <- NS(id)
+
+  modules <- append_reporter_module(modules)
 
   # show busy icon when `shiny` session is busy computing stuff
   # based on https://stackoverflow.com/questions/17325521/r-shiny-display-loading-message-while-function-is-running/22475216#22475216 # nolint: line_length.
@@ -113,6 +129,8 @@ srv_teal <- function(id, data, modules, filter = teal_slices()) {
   checkmate::assert_multi_class(data, c("teal_data", "teal_data_module", "reactive"))
   checkmate::assert_class(modules, "teal_modules")
   checkmate::assert_class(filter, "teal_slices")
+
+  modules <- append_reporter_module(modules)
 
   moduleServer(id, function(input, output, session) {
     logger::log_debug("srv_teal initializing.")

--- a/R/modules.R
+++ b/R/modules.R
@@ -641,6 +641,19 @@ append_module <- function(modules, module) {
   modules
 }
 
+#' @rdname module_teal
+#' @keywords internal
+#' @noRd
+append_reporter_module <- function(modules) {
+  if (is_arg_used(modules, "reporter") && length(extract_module(modules, "teal_module_previewer")) == 0) {
+    modules <- append_module(
+      modules,
+      reporter_previewer_module(server_args = list(previewer_buttons = c("download", "reset")))
+    )
+  }
+  modules
+}
+
 #' Extract/Remove module(s) of specific class
 #'
 #' Given a `teal_module` or a `teal_modules`, return the elements of the structure according to `class`.

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -1045,6 +1045,42 @@ testthat::describe("srv_teal teal_modules", {
       }
     )
   })
+
+  testthat::it("does not receive report_previewer when none of the modules contain reporter argument", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = teal.data::teal_data(iris = iris, mtcars = mtcars),
+        modules = modules(
+          module("module_1", server = function(id) {}),
+          module("module_2", server = function(id) {})
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_tab` = "report_previewer")
+        testthat::expect_setequal(names(modules_output), c("module_1", "module_2"))
+      }
+    )
+  })
+
+  testthat::it("receives one report_previewer module when any module contains reporter argument", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = teal.data::teal_data(iris = iris, mtcars = mtcars),
+        modules = modules(
+          module("module_1", server = function(id, reporter) {}),
+          module("module_2", server = function(id) {})
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_tab` = "report_previewer")
+        testthat::expect_setequal(names(modules_output), c("module_1", "module_2", "report_previewer"))
+      }
+    )
+  })
 })
 
 testthat::describe("srv_teal filters", {


### PR DESCRIPTION
Part of #1450 as it provides better API for people who consume teal as a shiny module.

