### PR TITLE
fix error

### DIFF
--- a/R/teal_reporter.R
+++ b/R/teal_reporter.R
@@ -74,7 +74,11 @@ TealReportCard <- R6::R6Class( # nolint: object_name.
   ),
   private = list(
     dispatch_block = function(block_class) {
-      eval(str2lang(block_class))
+      if (exists(block_class, getNamespace("teal"))) {
+        get(block_class)
+      } else {
+        super$dispatch_block(block_class)
+      }
     }
   )
 )

--- a/R/teal_reporter.R
+++ b/R/teal_reporter.R
@@ -75,8 +75,10 @@ TealReportCard <- R6::R6Class( # nolint: object_name.
   private = list(
     dispatch_block = function(block_class) {
       if (exists(block_class, getNamespace("teal"))) {
+        # for block classes which are in teal (TealSlicesBlock)
         get(block_class)
       } else {
+        # other block classes are in teal.reporter so we need to use super (ReporterCard) class
         super$dispatch_block(block_class)
       }
     }


### PR DESCRIPTION
closes insightsengineering/teal.reporter#302
`TealReporterCard` inherits from `ReporterCard`, when loading from file `TealReporterCard$dispatch_block(block_class)` is triggered. Because `TealReporterCard` is in `teal` namespace, `TextBlock` is failing as `TextBlock` is a `teal.reporter` (private) object. 

I hope code fix is self explanatory.