### PR TITLE
Vignette improvements

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -22,7 +22,7 @@ setOldClass("teal_modules")
 #'
 #' # Restricting datasets used by `teal_module`:
 #'
-#' The `datanames` argument controls which datasets are used by the module’s server. These datasets,
+#' The `datanames` argument controls which datasets are used by the module's server. These datasets,
 #' passed via server's `data` argument, are the only ones shown in the module's tab.
 #'
 #' When `datanames` is set to `"all"`, all datasets in the data object are treated as relevant.
@@ -35,7 +35,7 @@ setOldClass("teal_modules")
 #' Please see the _"Hidden datasets"_ section in `vignette("including-data-in-teal-applications").
 #'
 #' # `datanames` with `transformators`
-#' When transformators are specified, their `datanames` are added to the module’s `datanames`, which
+#' When transformators are specified, their `datanames` are added to the module's `datanames`, which
 #' changes the behavior as follows:
 #' - If `module(datanames)` is `NULL` and the `transformators` have defined `datanames`, the sidebar
 #'   will appear showing the `transformators`' datasets, instead of being hidden.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -72,12 +72,12 @@ articles:
   - title: Using `teal`
     navbar: Using `teal`
     contents:
-      - teal-as-a-module
+      - teal-as-a-shiny-module
       - teal-options
       - bootstrap-themes-in-teal
   - title: 📃 Technical blueprint
     desc: >
-      The purpose of the blueprint is to aid new developer’s comprehension of the
+      The purpose of the blueprint is to aid new developer's comprehension of the
       fundamental principles of the `teal` framework. We will explore crucial `teal`
       concepts such as data flow, actors, and filter panel, among others.
     contents:

--- a/man/teal_modules.Rd
+++ b/man/teal_modules.Rd
@@ -134,7 +134,7 @@ because they are used by the \code{mapping} argument of \code{\link[=teal_slices
 and the report previewer module \code{\link[=reporter_previewer_module]{reporter_previewer_module()}}, respectively.
 }
 \section{Restricting datasets used by \code{teal_module}:}{
-The \code{datanames} argument controls which datasets are used by the module’s server. These datasets,
+The \code{datanames} argument controls which datasets are used by the module's server. These datasets,
 passed via server's \code{data} argument, are the only ones shown in the module's tab.
 
 When \code{datanames} is set to \code{"all"}, all datasets in the data object are treated as relevant.
@@ -150,7 +150,7 @@ Please see the \emph{"Hidden datasets"} section in `vignette("including-data-in-
 }
 
 \section{\code{datanames} with \code{transformators}}{
-When transformators are specified, their \code{datanames} are added to the module’s \code{datanames}, which
+When transformators are specified, their \code{datanames} are added to the module's \code{datanames}, which
 changes the behavior as follows:
 \itemize{
 \item If \code{module(datanames)} is \code{NULL} and the \code{transformators} have defined \code{datanames}, the sidebar

--- a/vignettes/creating-custom-modules.Rmd
+++ b/vignettes/creating-custom-modules.Rmd
@@ -13,8 +13,8 @@ vignette: >
 ## Introduction
 
 The `teal` framework provides a large catalog of plug-in-ready analysis modules that can be incorporated into `teal` applications.
-However, it is also possible to create your own modules using the module function, which leverages Shiny modules.
-Each custom teal module is built as a Shiny module, combining Shiny's reactive capabilities with modularized UI and server logic to encapsulate functionality.
+However, it is also possible to create your own modules using the `module` function, which leverages Shiny modules.
+Each custom teal module is built as a [Shiny module](https://shiny.posit.co/r/articles/improve/modules/), combining Shiny's reactive capabilities with modularized UI and server logic to encapsulate functionality.
 This design enables a structured and reusable approach to creating interactive components that integrate seamlessly within the teal ecosystem.
 
 In this guide, we will use the simple histogram below as an example, and demonstrate how to convert this histogram function into a robust `teal` module step-by-step:
@@ -56,11 +56,11 @@ The UI function defines the controls and display area for the histogram.
 For this module, we will use:
 
 - **`selectInput` for Dataset**: Enables users to select a dataset from the list of available datasets.
-- **`selectInput` for Variable**: Allows users to choose a numeric variable from the chosen dataset, dynamically filtering out any non-numeric columns.
+- **`selectInput` for Variable**: Allows users to choose a numeric variable from the chosen dataset, dynamically filtering out any non-numeric variables from the choices.
 - **`plotOutput` for Histogram**: Displays the histogram once both dataset and variable inputs are selected.
-- **`verbatimTextOutput` for Code**: Automatically displays code that generated the plot based on user input.
+- **`verbatimTextOutput` for Code**: Automatically displays code that generated the plot based on the user input.
 
-Here’s the code for the `histogram_module_ui` function:
+Here's the code for the `histogram_module_ui` function:
 
 ```{r module_ui}
 library(teal)
@@ -92,9 +92,9 @@ For our histogram module, the server function will handle user interactions and 
 
 ### Passing the `data` Argument to the Server Function
 
-To begin, it’s essential to include the `data` argument in the server function definition.
+To begin, it's essential to include the `data` argument in the server function definition.
 
-This `data` argument holds the reactive `teal_data` object, which contains your datasets and any filters applied. By including `data`, we can ensure:
+This `data` argument holds the reactive `teal_data` object, which contains your datasets after updergoing any active filtering by the filter panel. By including `data`, we can ensure:
 
 - The server function receives a reactive version of `teal_data`, allowing it to automatically respond to changes.
 - The server can access the filtered datasets directly.
@@ -148,7 +148,7 @@ In this updated server function, we will perform the following:
 1. **Create `new_data`** as a modified version of `data()` using `within()`, dynamically injecting `input$dataset` and `input$variable`.
 2. **Render the Plot**: `renderPlot()` displays the plot by referencing the plot stored in the updated `teal_data` object, `new_data`.
 
-Here’s the code:
+Here's the code:
 
 ```{r module_server}
 # Server function for the custom histogram module with injected variables in within()
@@ -241,7 +241,7 @@ create_histogram_module <- function(label = "Histogram Module") {
 ## Integrating the Custom `teal` Module into a `teal` App
 
 With the custom `teal` module set up, it can now be integrated into a `teal` app.
-We’ll use `init()` from `teal` to specify the datasets and modules used in the app, then run the app to test the newly created module.
+We'll use `init()` from `teal` to specify the datasets and modules used in the app, then run the app to test the newly created module.
 
 ```{r app_init}
 # Define datasets in `teal_data`
@@ -282,12 +282,12 @@ knitr::include_url(url, height = "800px")
 
 ## What's next?
 
-Now that you’ve mastered the essentials of building and integrating modules in `teal`, you’re ready to explore more advanced features.
-`teal` offers a wide range of capabilities to enhance your module’s functionality and user experience.
+Now that you've mastered the essentials of building and integrating modules in `teal`, you're ready to explore more advanced features.
+`teal` offers a wide range of capabilities to enhance your module's functionality and user experience.
 
 ### Adding reporting to a module
 
-Enhance your custom `teal` module with reporting features! Dive into [this vignette](adding-support-for-reporting.html) to see just how simple it is to add powerful reporting capabilities and elevate your module’s impact.
+Enhance your custom `teal` module with reporting features! Dive into [this vignette](adding-support-for-reporting.html) to see just how simple it is to add powerful reporting capabilities and elevate your module's impact.
 
 ### Using standard widgets in your custom module
 The [`teal.widgets`](https://insightsengineering.github.io/teal.widgets/latest-tag/) package provides various widgets which can be leveraged to quickly create standard elements in your custom `teal` module.

--- a/vignettes/creating-custom-modules.Rmd
+++ b/vignettes/creating-custom-modules.Rmd
@@ -94,7 +94,7 @@ For our histogram module, the server function will handle user interactions and 
 
 To begin, it's essential to include the `data` argument in the server function definition.
 
-This `data` argument holds the reactive `teal_data` object, which contains your datasets after updergoing any active filtering by the filter panel. By including `data`, we can ensure:
+This `data` argument holds the reactive `teal_data` object, which contains your datasets after applying any active filtering by the filter panel. By including `data`, we can ensure:
 
 - The server function receives a reactive version of `teal_data`, allowing it to automatically respond to changes.
 - The server can access the filtered datasets directly.

--- a/vignettes/customizing-module-output.Rmd
+++ b/vignettes/customizing-module-output.Rmd
@@ -41,171 +41,100 @@ To use decorators effectively, certain requirements must be met:
 
 It is recommended to review the module documentation or source code to understand its internal object naming and object class before applying decorators.
 
-## Decorators in `teal`
+## Example Module which will be decorated
 
-One way to adjust input data or customize module outputs in `teal` is by using transformators created through `teal_transform_module()`.
+Here's a simple module `tm_plot()` to showcase how decorator works.
 
-In the chapter below, we will demonstrate how to create the simplest static decorator with only a server component.
-Later, we will explore more advanced use cases where decorators include a UI.
-You will also learn about a convenient function, `make_teal_transform_server()`, which simplifies writing decorators.
-
-The chapter concludes with an example module that utilizes decorators and a snippet demonstrating how to use this module in a `teal` application.
-
-### Non-interactive decorators
-
-The simplest way to create a decorator is to use `teal_transform_module()` with only `server` argument provided (i.e. without UI part).
-This approach adds functionality solely to the server code of the module.
-
-In the following example, we assume that the module contains an object (of class `ggplot2`) named `plot`.
-We modify the title and x-axis label of plot:
-
-```{r, message = FALSE}
+```{r setup, include=FALSE}
+library(ggplot2)
 library(teal)
-static_decorator <- teal_transform_module(
-  label = "Static decorator",
-  server = function(id, data) {
-    moduleServer(id, function(input, output, session) {
-      reactive({
-        req(data())
-        within(data(), {
-          plot <- plot +
-            ggtitle("This is title") +
-            xlab("x axis")
-        })
-      })
-    })
-  }
-)
 ```
 
-To simplify the repetitive elements of writing new decorators
-(e.g., `function(id, data), moduleServer, reactive, within(data, ...)`),
-you can use the `make_teal_transform_server()` convenience function, which takes a `language` as input:
+```{r undecorated_app}
+library(ggplot2)
+library(teal)
 
-```{r}
-static_decorator_lang <- teal_transform_module(
-  label = "Static decorator (language)",
-  server = make_teal_transform_server(
-    expression(
-      plot <- plot +
-        ggtitle("This is title") +
-        xlab("x axis title")
-    )
-  )
-)
-```
-
-### Interactive decorators
-
-To create a decorator with user interactivity, you can add (optional) UI part and use it in server accordingly (i.e. a typical `shiny` module).
-In the example below, the x-axis title is set dynamically via a `textInput`, allowing users to specify their preferred label.
-Note how the input parameters are passed to the `within()` function using its `...` argument.
-
-```{r}
-interactive_decorator <- teal_transform_module(
-  label = "Interactive decorator",
-  ui = function(id) {
-    ns <- NS(id)
-    div(
-      textInput(ns("x_axis_title"), "X axis title", value = "x axis")
-    )
-  },
-  server = function(id, data) {
-    moduleServer(id, function(input, output, session) {
-      reactive({
-        req(data())
-        within(data(),
-          {
-            plot <- plot +
-              ggtitle("This is title") +
-              xlab(my_title)
-          },
-          my_title = input$x_axis_title
-        )
-      })
-    })
-  }
-)
-```
-
-As in the earlier examples, `make_teal_transform_server()` can simplify the creation of the server component.
-This wrapper requires you to use `input` object names directly in the expression - note that we have `xlab(x_axis_title)` and not `my_title = input$x_axis_title` together with `xlab(my_title)`.
-
-```{r}
-interactive_decorator_lang <- teal_transform_module(
-  label = "Interactive decorator (language)",
-  ui = function(id) {
-    ns <- NS(id)
-    div(
-      textInput(ns("y_axis_title"), "Y axis title", value = "y axis")
-    )
-  },
-  server = make_teal_transform_server(
-    expression(
-      plot <- plot +
-        ggtitle("This is title") +
-        ylab(y_axis_title)
-    )
-  )
-)
-```
-
-## Handling Various Object Names
-
-`teal_transform_module` relies on the names of objects created within a module.
-Writing a decorator that applies to any module can be challenging since different modules may use different object names.
-It is recommended to create a library of decorator functions that can be adapted to the specific object names used in `teal` modules.
-
-In the following example, pay attention to the `output_name` parameter to see how a decorator can be applied to multiple modules:
-
-```{r}
-gg_xlab_decorator <- function(output_name) {
-  teal_transform_module(
-    label = "X-axis decorator",
+tm_plot <- function(label = "module") {
+  module(
+    label = label,
     ui = function(id) {
       ns <- NS(id)
       div(
-        textInput(ns("x_axis_title"), "X axis title", value = "x axis")
+        selectInput(ns("dataname"), label = "select dataname", choices = NULL),
+        selectInput(ns("x"), label = "select x", choices = NULL),
+        selectInput(ns("y"), label = "select y", choices = NULL),
+        plotOutput(ns("plot")),
+        verbatimTextOutput(ns("text"))
       )
     },
     server = function(id, data) {
       moduleServer(id, function(input, output, session) {
-        reactive({
-          req(data())
+        observeEvent(data(), {
+          updateSelectInput(inputId = "dataname", choices = names(data()))
+        })
+
+        observeEvent(input$dataname, {
+          req(input$dataname)
+          updateSelectInput(inputId = "x", choices = colnames(data()[[input$dataname]]))
+          updateSelectInput(inputId = "y", choices = colnames(data()[[input$dataname]]))
+        })
+
+        dataname <- reactive(req(input$dataname))
+        x <- reactive({
+          req(input$x, input$x %in% colnames(data()[[dataname()]]))
+          input$x
+        })
+
+        y <- reactive({
+          req(input$y, input$y %in% colnames(data()[[dataname()]]))
+          input$y
+        })
+        plot_data <- reactive({
+          req(dataname(), x(), y())
           within(data(),
             {
-              output_name <- output_name +
-                xlab(x_axis_title)
+              plot <- ggplot2::ggplot(dataname, ggplot2::aes(x = x, y = y)) +
+                ggplot2::geom_point()
             },
-            x_axis_title = input$x_axis_title,
-            output_name = as.name(output_name)
+            dataname = as.name(dataname()),
+            x = as.name(x()),
+            y = as.name(y())
           )
+        })
+
+        plot_r <- reactive({
+          plot_data()[["plot"]]
+        })
+
+        output$plot <- renderPlot(plot_r())
+        output$text <- renderText({
+          teal.code::get_code(req(plot_data()))
         })
       })
     }
   )
 }
+
+app <- init(
+  data = teal_data(iris = iris, mtcars = mtcars),
+  modules = modules(
+    tm_plot("identity")
+  )
+)
+
+if (interactive()) {
+  shinyApp(app$ui, app$server)
+}
 ```
 
-Decorator failures are managed by an internal `teal` mechanism called **trigger on success**, which ensures that the `data`
-object within the module remains intact.
-If a decorator fails, the outputs will not be shown, and an appropriate error message will be displayed.
+```{r shinylive_iframe_1, echo = FALSE, out.width = '150%', out.extra = 'style = "position: relative; z-index:1"', eval = requireNamespace("roxy.shinylive", quietly = TRUE) && knitr::is_html_output() && identical(Sys.getenv("IN_PKGDOWN"), "true")}
+code <- paste0(c(
+  "interactive <- function() TRUE",
+  knitr::knit_code$get("undecorated_app")
+), collapse = "\n")
 
-```{r}
-failing_decorator <- teal_transform_module(
-  label = "Failing decorator",
-  ui = function(id) {
-    ns <- NS(id)
-    div(
-      textInput(ns("x_axis_title"), "X axis title", value = "x axis")
-    )
-  },
-  server = function(id, data) {
-    moduleServer(id, function(input, output, session) {
-      reactive(stop("\nThis is an error produced by decorator\n"))
-    })
-  }
-)
+url <- roxy.shinylive::create_shinylive_url(code)
+knitr::include_url(url, height = "800px")
 ```
 
 ## Include Decorators in a `teal` Module
@@ -213,9 +142,9 @@ failing_decorator <- teal_transform_module(
 To include decorators in a `teal` module, pass them as arguments (`ui_args` and `server_args`) to the module’s `ui` and
 `server` components, where they will be used by `ui_transform_teal_data` and `srv_transform_teal_data`.
 
-Please find an example module for the sake of this article:
+Please find the module `tm_decorated_plot()` which is the modified `tm_plot()` ready for decoration:
 
-```{r}
+```{r tm_decorated_plot}
 tm_decorated_plot <- function(label = "module", transformators = list(), decorators = NULL) {
   checkmate::assert_list(decorators, "teal_transform_module", null.ok = TRUE)
 
@@ -292,13 +221,178 @@ tm_decorated_plot <- function(label = "module", transformators = list(), decorat
 }
 ```
 
+## Decorators in `teal`
+
+One way to adjust input data or customize module outputs in `teal` is by using transformators created through `teal_transform_module()`.
+
+In the chapter below, we will demonstrate how to create the simplest static decorator with only a server component.
+Later, we will explore more advanced use cases where decorators include a UI.
+You will also learn about a convenient function, `make_teal_transform_server()`, which simplifies writing decorators.
+
+The chapter concludes with an example module that utilizes decorators and a snippet demonstrating how to use this module in a `teal` application.
+
+### Non-interactive decorators
+
+The simplest way to create a decorator is to use `teal_transform_module()` with only `server` argument provided (i.e. without UI part).
+This approach adds functionality solely to the server code of the module.
+
+In the following example, we assume that the module contains an object (of class `ggplot2`) named `plot`.
+We modify the title and x-axis label of plot:
+
+```{r static_decorator}
+static_decorator <- teal_transform_module(
+  label = "Static decorator",
+  server = function(id, data) {
+    moduleServer(id, function(input, output, session) {
+      reactive({
+        req(data())
+        within(data(), {
+          plot <- plot +
+            ggtitle("This is title") +
+            xlab("x axis")
+        })
+      })
+    })
+  }
+)
+```
+
+To simplify the repetitive elements of writing new decorators
+(e.g., `function(id, data), moduleServer, reactive, within(data, ...)`),
+you can use the `make_teal_transform_server()` convenience function, which takes a `language` as input:
+
+```{r static_decorator_lang}
+static_decorator_lang <- teal_transform_module(
+  label = "Static decorator (language)",
+  server = make_teal_transform_server(
+    expression(
+      plot <- plot +
+        ggtitle("This is title") +
+        xlab("x axis title")
+    )
+  )
+)
+```
+
+### Interactive decorators
+
+To create a decorator with user interactivity, you can add (optional) UI part and use it in server accordingly (i.e. a typical `shiny` module).
+In the example below, the x-axis title is set dynamically via a `textInput`, allowing users to specify their preferred label.
+Note how the input parameters are passed to the `within()` function using its `...` argument.
+
+```{r interactive_decorator}
+interactive_decorator <- teal_transform_module(
+  label = "Interactive decorator",
+  ui = function(id) {
+    ns <- NS(id)
+    div(
+      textInput(ns("x_axis_title"), "X axis title", value = "x axis")
+    )
+  },
+  server = function(id, data) {
+    moduleServer(id, function(input, output, session) {
+      reactive({
+        req(data())
+        within(data(),
+          {
+            plot <- plot +
+              ggtitle("This is title") +
+              xlab(my_title)
+          },
+          my_title = input$x_axis_title
+        )
+      })
+    })
+  }
+)
+```
+
+As in the earlier examples, `make_teal_transform_server()` can simplify the creation of the server component.
+This wrapper requires you to use `input` object names directly in the expression - note that we have `xlab(x_axis_title)` and not `my_title = input$x_axis_title` together with `xlab(my_title)`.
+
+```{r interactive_decorator_lang}
+interactive_decorator_lang <- teal_transform_module(
+  label = "Interactive decorator (language)",
+  ui = function(id) {
+    ns <- NS(id)
+    div(
+      textInput(ns("y_axis_title"), "Y axis title", value = "y axis")
+    )
+  },
+  server = make_teal_transform_server(
+    expression(
+      plot <- plot +
+        ggtitle("This is title") +
+        ylab(y_axis_title)
+    )
+  )
+)
+```
+
+## Handling Various Object Names
+
+`teal_transform_module` relies on the names of objects created within a module.
+Writing a decorator that applies to any module can be challenging since different modules may use different object names.
+It is recommended to create a library of decorator functions that can be adapted to the specific object names used in `teal` modules.
+
+In the following example, pay attention to the `output_name` parameter to see how a decorator can be applied to multiple modules:
+
+```{r gg_xlab_decorator}
+gg_xlab_decorator <- function(output_name) {
+  teal_transform_module(
+    label = "X-axis decorator",
+    ui = function(id) {
+      ns <- NS(id)
+      div(
+        textInput(ns("x_axis_title"), "X axis title", value = "x axis")
+      )
+    },
+    server = function(id, data) {
+      moduleServer(id, function(input, output, session) {
+        reactive({
+          req(data())
+          within(data(),
+            {
+              output_name <- output_name +
+                xlab(x_axis_title)
+            },
+            x_axis_title = input$x_axis_title,
+            output_name = as.name(output_name)
+          )
+        })
+      })
+    }
+  )
+}
+```
+
+Decorator failures are managed by an internal `teal` mechanism called **trigger on success**, which ensures that the `data`
+object within the module remains intact.
+If a decorator fails, the outputs will not be shown, and an appropriate error message will be displayed.
+
+```{r failing_decorator}
+failing_decorator <- teal_transform_module(
+  label = "Failing decorator",
+  ui = function(id) {
+    ns <- NS(id)
+    div(
+      textInput(ns("x_axis_title"), "X axis title", value = "x axis")
+    )
+  },
+  server = function(id, data) {
+    moduleServer(id, function(input, output, session) {
+      reactive(stop("\nThis is an error produced by decorator\n"))
+    })
+  }
+)
+```
+
 ## `teal` App With Decorators
 
 Now that we have the `teal` module ready, let's apply all the decorators we’ve created in our `teal` app.
 Please note that a module can accept any number of decorators as demonstrated in the example below.
 
-```{r}
-library(ggplot2)
+```{r app}
 app <- init(
   data = teal_data(iris = iris, mtcars = mtcars),
   modules = modules(
@@ -321,3 +415,20 @@ if (interactive()) {
 By utilizing `teal_transform_module()`, decorators can efficiently modify and enhance the outputs of a `teal` module without altering its original implementation.
 Whether you need simple static adjustments or dynamic UI-driven transformations, decorators provide a powerful way to customize plots, tables, or any other module output.
 
+```{r shinylive_iframe_2, echo = FALSE, out.width = '150%', out.extra = 'style = "position: relative; z-index:1"', eval = requireNamespace("roxy.shinylive", quietly = TRUE) && knitr::is_html_output() && identical(Sys.getenv("IN_PKGDOWN"), "true")}
+code <- paste0(c(
+  "interactive <- function() TRUE",
+  knitr::knit_code$get("setup"),
+  knitr::knit_code$get("static_decorator"),
+  knitr::knit_code$get("static_decorator_lang"),
+  knitr::knit_code$get("interactive_decorator"),
+  knitr::knit_code$get("interactive_decorator_lang"),
+  knitr::knit_code$get("gg_xlab_decorator"),
+  knitr::knit_code$get("failing_decorator"),
+  knitr::knit_code$get("tm_decorated_plot"),
+  knitr::knit_code$get("app")
+), collapse = "\n")
+
+url <- roxy.shinylive::create_shinylive_url(code)
+knitr::include_url(url, height = "800px")
+```

--- a/vignettes/data-transform-as-shiny-module.Rmd
+++ b/vignettes/data-transform-as-shiny-module.Rmd
@@ -67,7 +67,7 @@ knitr::include_url(url, height = "800px")
 Next, let's create a **single transformator** using `teal_transform_module()`.
 This example enables users to subset the first `n` rows of the `iris` dataset based on their input.
 
-Here’s how we can implement this:
+Here's how we can implement this:
 
 1. **UI Component**: We create a `numericInput` in the `ui` that allows users to specify the number of rows they want to display.
 2. **Server Logic**: In the `server` function, we take in a reactive `data` object, perform the transformation to extract the first `n` rows of the `iris` dataset, and return the updated reactive `data`.
@@ -142,7 +142,7 @@ knitr::include_url(url, height = "800px")
 
 We could also add **multiple transformators** to the app by including several instances of `teal_transform_module` in a list.
 
-For example, let’s add another transformation to the `mtcars` dataset. This transformation creates a new column containing the `rownames` of `mtcars`.
+For example, let's add another transformation to the `mtcars` dataset. This transformation creates a new column containing the `rownames` of `mtcars`.
 Unlike the previous example, this module does not include any interactive UI elements.
 
 ```{r app_3}

--- a/vignettes/getting-started-with-teal.Rmd
+++ b/vignettes/getting-started-with-teal.Rmd
@@ -124,7 +124,7 @@ For more details see [this vignette](including-data-in-teal-applications.html).
 
 ### Embedding teal in shiny application
 
-Advanced shiny users can include teal application in their Shiny application. For further details see [teal as a module](teal-as-a-module.html).
+Advanced shiny users can include teal application in their Shiny application. For further details see [teal as a module](teal-as-shiny-module.html).
 
 ## Where to go next
 

--- a/vignettes/teal-as-a-shiny-module.Rmd
+++ b/vignettes/teal-as-a-shiny-module.Rmd
@@ -1,28 +1,30 @@
 ---
-title: "Teal as a Module"
+title: "Teal as a Shiny Module"
 author: "NEST CoreDev"
 output: 
   rmarkdown::html_vignette:
     toc: true
 vignette: >
-  %\VignetteIndexEntry{Teal as a Module}
+  %\VignetteIndexEntry{Teal as a Shiny Module}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
-# Introduction
+## Introduction
 
-A Shiny developer interested in embedding Teal application into its own app, can use the Teal module composed of `ui_teal()` and `srv_teal()` functions. 
-Unlike `init()`, this module will not automatically include session info footer, but it is possible to add it manually with `ui_session_info()` and `srv_session_info()`.
-Using Teal as modules offers several advantages such as:
+A Shiny developer can embed a Teal application into their own Shiny app by using Teal's Shiny module components: `ui_teal()` and `srv_teal()`.
+This approach differs from using `init()` and offers greater flexibility. While `init()` includes a session info footer automatically,
+when using Teal as a Shiny module you can optionally add it manually with `ui_session_info()` and `srv_session_info()`.
+Using Teal as a Shiny module offers several advantages:
 
-- Including one or multiple Teal applications in other app.
-- Run Teal applications based on the dynamically created components like initial data, modules, filters.
+- Embedding one or more Teal applications within a larger Shiny app
+- Creating Teal applications with dynamically generated components (initial data, teal modules, filters)
 
-# Example
+## Example
 
-Example below demonstrates how to embed Teal as a module in a Shiny application. 
-Here, user can select dataset names which will be handed over and displayed in the Teal module. On the server side `srv_teal()` is called using the reactive `teal_data` object passed from the server of the parent app.
+The following example demonstrates embedding Teal as a Shiny module within a larger Shiny application.
+Users can select dataset names which are passed to the embedded Teal component.
+On the server side, `srv_teal()` is called with a reactive teal_data object passed from the parent app's server.
 
 ```{r setup, include=FALSE}
 library(teal)


### PR DESCRIPTION
Part of https://github.com/insightsengineering/nestdevs-tasks/issues/99

Changes:
- `customizing-module-output.Rmd` adds shinylive and restructure the example to showcase undecorated module earlier so it becomes easy to see what "decoration" is about and it also helps in migrating modules to "decoratable modules".
- `teal-as-a-module.Rmd` becomes `teal-as-a-shiny-module.Rmd` to reduce the ambiguous usage of "module" which means "shiny module" and not "teal module" in this case.
- `creating-custom-modules.Rmd` minor changes
- Use Ascii apostrophe throughout the package