### PR TITLE
fix: add missing staged.dependencies entry

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -5,6 +5,7 @@ current_repo:
 upstream_repos:
   insightsengineering/roxy.shinylive:
     repo: insightsengineering/roxy.shinylive
+    host: https://github.com
   insightsengineering/teal.widgets:
     repo: insightsengineering/teal.widgets
     host: https://github.com


### PR DESCRIPTION
This addresses an error during staged.dependencies installation of `teal`:
```
File ./staged_dependencies.yaml invalid, field upstream_repos cannot be an array and must have entries repo, host
```