### PR TITLE
specify dev branch for dependencies in Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,6 +72,8 @@ Suggests:
     testthat (>= 3.2.0),
     withr (>= 2.1.0),
     yaml (>= 1.1.0)
+Remotes:
+    insightsengineering/teal.reporter@redesign@main
 VignetteBuilder:
     knitr,
     rmarkdown


### PR DESCRIPTION
Since `test@bslib@main` is syncing with [`teal.reporter/redesign@main`](https://github.com/insightsengineering/teal.reporter/tree/redesign%40main) then it should specify the dev branch in Remotes
