### PR TITLE
Remove incorrect changelog item (1/2)

### DIFF
--- a/latest-tag/news/index.html
+++ b/latest-tag/news/index.html
@@ -139,7 +139,6 @@
 <li>Possibility to download lockfile to restore app session for reproducibility (<a href="https://github.com/insightsengineering/teal/issues/479" class="external-link">#479</a>).</li>
 <li>Datasets which name starts with <code>.</code> are ignored when <code>module</code>’s <code>datanames</code> is set as <code>"all"</code>.</li>
 <li>Added warning when reserved <code>datanames</code>, such as <code>all</code> and <code>.raw_data</code> are being used.</li>
-<li>Added <code>add_custom_server()</code> to allow adding custom server logic to the main shiny server function of a teal app.</li>
 </ul>
 </div>
 <div class="section level4">

--- a/main/news/index.html
+++ b/main/news/index.html
@@ -139,7 +139,6 @@
 <li>Possibility to download lockfile to restore app session for reproducibility (<a href="https://github.com/insightsengineering/teal/issues/479" class="external-link">#479</a>).</li>
 <li>Datasets which name starts with <code>.</code> are ignored when <code>module</code>’s <code>datanames</code> is set as <code>"all"</code>.</li>
 <li>Added warning when reserved <code>datanames</code>, such as <code>all</code> and <code>.raw_data</code> are being used.</li>
-<li>Added <code>add_custom_server()</code> to allow adding custom server logic to the main shiny server function of a teal app.</li>
 </ul>
 </div>
 <div class="section level4">

--- a/release-candidate/news/index.html
+++ b/release-candidate/news/index.html
@@ -138,7 +138,6 @@
 <li>Possibility to download lockfile to restore app session for reproducibility (<a href="https://github.com/insightsengineering/teal/issues/479" class="external-link">#479</a>).</li>
 <li>Datasets which name starts with <code>.</code> are ignored when <code>module</code>’s <code>datanames</code> is set as <code>"all"</code>.</li>
 <li>Added warning when reserved <code>datanames</code>, such as <code>all</code> and <code>.raw_data</code> are being used.</li>
-<li>Added <code>add_custom_server()</code> to allow adding custom server logic to the main shiny server function of a teal app.</li>
 </ul>
 </div>
 <div class="section level4">

--- a/v0.16.0-rc1/news/index.html
+++ b/v0.16.0-rc1/news/index.html
@@ -138,7 +138,6 @@
 <li>Possibility to download lockfile to restore app session for reproducibility (<a href="https://github.com/insightsengineering/teal/issues/479" class="external-link">#479</a>).</li>
 <li>Datasets which name starts with <code>.</code> are ignored when <code>module</code>’s <code>datanames</code> is set as <code>"all"</code>.</li>
 <li>Added warning when reserved <code>datanames</code>, such as <code>all</code> and <code>.raw_data</code> are being used.</li>
-<li>Added <code>add_custom_server()</code> to allow adding custom server logic to the main shiny server function of a teal app.</li>
 </ul>
 </div>
 <div class="section level4">

--- a/v0.16.0-rc2/news/index.html
+++ b/v0.16.0-rc2/news/index.html
@@ -138,7 +138,6 @@
 <li>Possibility to download lockfile to restore app session for reproducibility (<a href="https://github.com/insightsengineering/teal/issues/479" class="external-link">#479</a>).</li>
 <li>Datasets which name starts with <code>.</code> are ignored when <code>module</code>’s <code>datanames</code> is set as <code>"all"</code>.</li>
 <li>Added warning when reserved <code>datanames</code>, such as <code>all</code> and <code>.raw_data</code> are being used.</li>
-<li>Added <code>add_custom_server()</code> to allow adding custom server logic to the main shiny server function of a teal app.</li>
 </ul>
 </div>
 <div class="section level4">

--- a/v0.16.0/news/index.html
+++ b/v0.16.0/news/index.html
@@ -139,7 +139,6 @@
 <li>Possibility to download lockfile to restore app session for reproducibility (<a href="https://github.com/insightsengineering/teal/issues/479" class="external-link">#479</a>).</li>
 <li>Datasets which name starts with <code>.</code> are ignored when <code>module</code>’s <code>datanames</code> is set as <code>"all"</code>.</li>
 <li>Added warning when reserved <code>datanames</code>, such as <code>all</code> and <code>.raw_data</code> are being used.</li>
-<li>Added <code>add_custom_server()</code> to allow adding custom server logic to the main shiny server function of a teal app.</li>
 </ul>
 </div>
 <div class="section level4">


### PR DESCRIPTION
Part of  #1500

This PR makes sure that our tagged pkgdown changelog does not show this incorrect line. Since the tagged pkgdown version will not be re-rendered again, this change will persist.
