### PR TITLE
Improve the teal sidebar

### DIFF
--- a/inst/css/sidebar.css
+++ b/inst/css/sidebar.css
@@ -166,38 +166,37 @@ a.remove {
   -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
 }
 
-.teal-transform-panel .accordion .accordion-button,
+.teal-transform-panel .accordion-body {
+  padding: 0;
+}
+
 .teal-active-data-summary-panel .accordion .accordion-button {
   background-color: rgba(var(--bs-primary-rgb), 1);
   color: var(--bs-white);
 }
-.teal-transform-panel .accordion .accordion-button:hover,
 .teal-active-data-summary-panel .accordion .accordion-button:hover {
   background-color: rgba(var(--bs-primary-rgb), 0.75);
   color: var(--bs-white);
 }
 
-.teal-transform-panel .accordion-body .accordion .accordion-button {
+.teal-filter-panel,
+.teal-transform-panel {
+  margin-top: 10px;
+}
+
+.teal-filter-panel .accordion-button:not(.accordion-body .accordion-button),
+.teal-transform-panel .accordion-button:not(.accordion-body .accordion-button) {
   background-color: rgba(var(--bs-primary-rgb), 1);
   color: var(--bs-white);
 }
-.teal-transform-panel .accordion-body .accordion .accordion-button:hover {
+
+.teal-filter-panel
+  .accordion-button:not(.accordion-body .accordion-button):hover,
+.teal-transform-panel
+  .accordion-button:not(.accordion-body .accordion-button):hover {
   background-color: rgba(var(--bs-primary-rgb), 0.75);
   color: var(--bs-white);
 }
-/* .teal-transform-panel .accordion .accordion-body,
-.teal-active-data-summary-panel .accordion .accordion-body {
-  background-color: rgba(var(--bs-primary-rgb), 0.05);
-} */
-
-/* .teal-transform-panel .accordion-body,
-.teal-active-data-summary-panel .accordion-body {
-  border: solid 1.5px var(--bs-primary);
-}
-
-.teal-filter-panel .accordion-body {
-  border: solid 1.5px var(--bs-gray);
-} */
 
 .sidebar-toggle-buttons .data-summary-toggle {
   color: rgba(var(--bs-primary-rgb), 1);


### PR DESCRIPTION
Companion of https://github.com/insightsengineering/teal.slice/pull/647

UI changes the following which address [this comment](https://github.com/insightsengineering/teal/pull/1507#issuecomment-2818676604):
- The Active data summary, Filter Data, and Transform data accordions headers use primary colors (blue default).
- The padding inside the accordion body is removed
- The gap between the three accordions is reduced

<img width="663" alt="Screenshot 2025-04-24 at 10 34 42 AM" src="https://github.com/user-attachments/assets/a744a1e3-a8e2-4ef1-bfa4-afbd840609c8" />
