### PR TITLE
Delayed data: inserting the UI

### DIFF
--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -272,7 +272,7 @@ srv_teal_module.teal_modules <- function(id,
       }
     })
 
-    modules_output <- sapply(
+    lapply(
       names(modules$children),
       function(module_id) {
         srv_teal_module(
@@ -288,11 +288,8 @@ srv_teal_module.teal_modules <- function(id,
               identical(data_load_status(), "ok")
           )
         )
-      },
-      simplify = FALSE
+      }
     )
-
-    modules_output
   })
 }
 

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -303,8 +303,8 @@ srv_teal_module.teal_module <- function(id,
                                         reporter = teal.reporter::Reporter$new(),
                                         data_load_status = reactive("ok"),
                                         is_active = reactive(TRUE)) {
-  logger::log_debug("srv_teal_module.teal_module initializing the module: { deparse1(modules$label) }.")
   moduleServer(id = id, module = function(input, output, session) {
+    logger::log_debug("srv_teal_module.teal_module initializing the module: { deparse1(modules$label) }.")
     module_out <- reactiveVal()
 
     active_datanames <- reactive({

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -296,7 +296,7 @@ srv_teal_module.teal_modules <- function(id,
       names(modules$children),
       function(module_id) {
         srv_teal_module(
-          id = module_id,
+          id = paste0("module-", module_id),
           data = data,
           modules = modules$children[[module_id]],
           datasets = datasets,

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -107,7 +107,6 @@ ui_teal_module.teal_module <- function(id, modules, ..., depth = 0L) {
   # browser()
   # #teal-teal_modules-module-example_teal_module
   args <- c(list(id = ns("module")), modules$ui_args)
-  logger::log_info("ns_teal_module: ", ns(NULL))
   ui_teal <- tags$div(
     tags$div(
       id = ns("transform_failure_info"),

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -102,17 +102,19 @@ ui_teal_module.teal_modules <- function(id, modules, ..., depth = 0L) {
 ui_teal_module.teal_module <- function(id, modules, ..., depth = 0L) {
   checkmate::assert_count(depth)
   ns <- NS(id)
+  l <- list(...)
+  ok <- !is.null(l) && isTRUE(l$ok)
+  # browser()
+  # #teal-teal_modules-module-example_teal_module
   args <- c(list(id = ns("module")), modules$ui_args)
   logger::log_info("ns_teal_module: ", ns(NULL))
   ui_teal <- tags$div(
-    shinyjs::hidden(
-      tags$div(
-        id = ns("transform_failure_info"),
-        class = "teal_validated",
-        div(
-          class = "teal-output-warning",
-          "One of transformators failed. Please check its inputs."
-        )
+    tags$div(
+      id = ns("transform_failure_info"),
+      class = "teal_validated",
+      div(
+        class = "teal-output-warning",
+        "One of transformators failed. Please check its inputs."
       )
     ),
     tags$div(
@@ -280,9 +282,11 @@ srv_teal_module.teal_modules <- function(id,
         # shinyjs::show("wrapper")
         # shinyjs::enable(selector = tabs_selector)
       } else if (identical(data_load_status(), "teal_data_module failed")) {
+        shiny::removeUI(selector = tabs_selector)
         logger::log_debug("srv_teal_module@1 disabling modules tabs.")
         shinyjs::disable(selector = tabs_selector)
       } else if (identical(data_load_status(), "external failed")) {
+        shiny::removeUI(selector = tabs_selector)
         logger::log_debug("srv_teal_module@1 hiding modules tabs.")
         shinyjs::hide(session$ns("wrapper"))
       }

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -111,8 +111,7 @@ ui_teal_module.teal_module <- function(id, modules, ..., depth = 0L) {
         "One of transformators failed. Please check its inputs.",
         class = "teal-output-warning"
       )
-    )
-    ),
+    )),
     tags$div(
       id = ns("teal_module_ui"),
       tags$div(
@@ -267,13 +266,16 @@ srv_teal_module.teal_modules <- function(id,
     observeEvent(data_load_status(), {
       tabs_selector <- sprintf("#%s", session$ns("active_tab"))
       if (identical(data_load_status(), "ok")) {
-        ui_modules <- ui_teal_module(id = session$ns("module"),
-                                     modules = modules,
-                                     ok = TRUE)
-        shiny::insertUI(selector = tabs_selector,
-                        where = "beforeEnd",
-                        ui = ui_modules)
-
+        ui_modules <- ui_teal_module(
+          id = session$ns("module"),
+          modules = modules,
+          ok = TRUE
+        )
+        shiny::insertUI(
+          selector = tabs_selector,
+          where = "beforeEnd",
+          ui = ui_modules
+        )
       } else if (identical(data_load_status(), "teal_data_module failed")) {
         logger::log_debug("srv_teal_module@1 disabling modules tabs.")
         shinyjs::disable(selector = tabs_selector)

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -55,12 +55,9 @@ ui_teal_module.teal_modules <- function(id, modules, ..., depth = 0L) {
   ns <- NS(id)
   l <- list(...)
   add_ui <- !is.null(modules$children) && isTRUE(l$ok)
-  id_wrapper <- ns("wrapper")
 
-  logger::log_info("teal_moduleSS wrapper:", id_wrapper)
-  logger::log_info("teal_moduleSS tab: ", ns("active_tab"))
   tags$div(
-    id = id_wrapper,
+    id = ns("wrapper"),
     do.call(
       switch(as.character(depth),
         "0" = bslib::navset_pill,
@@ -104,8 +101,7 @@ ui_teal_module.teal_module <- function(id, modules, ..., depth = 0L) {
   ns <- NS(id)
   l <- list(...)
   ok <- !is.null(l) && isTRUE(l$ok)
-  # browser()
-  # #teal-teal_modules-module-example_teal_module
+
   args <- c(list(id = ns("module")), modules$ui_args)
   ui_teal <- tags$div(
     shinyjs::hidden(tags$div(
@@ -115,7 +111,8 @@ ui_teal_module.teal_module <- function(id, modules, ..., depth = 0L) {
         "One of transformators failed. Please check its inputs.",
         class = "teal-output-warning"
       )
-    )),
+    )
+    ),
     tags$div(
       id = ns("teal_module_ui"),
       tags$div(
@@ -270,7 +267,6 @@ srv_teal_module.teal_modules <- function(id,
     observeEvent(data_load_status(), {
       tabs_selector <- sprintf("#%s", session$ns("active_tab"))
       if (identical(data_load_status(), "ok")) {
-        logger::log_info(session$ns("module"))
         ui_modules <- ui_teal_module(id = session$ns("module"),
                                      modules = modules,
                                      ok = TRUE)
@@ -278,14 +274,10 @@ srv_teal_module.teal_modules <- function(id,
                         where = "beforeEnd",
                         ui = ui_modules)
 
-        # shinyjs::show("wrapper")
-        # shinyjs::enable(selector = tabs_selector)
       } else if (identical(data_load_status(), "teal_data_module failed")) {
-        shiny::removeUI(selector = tabs_selector)
         logger::log_debug("srv_teal_module@1 disabling modules tabs.")
         shinyjs::disable(selector = tabs_selector)
       } else if (identical(data_load_status(), "external failed")) {
-        shiny::removeUI(selector = tabs_selector)
         logger::log_debug("srv_teal_module@1 hiding modules tabs.")
         shinyjs::hide(session$ns("wrapper"))
       }

--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -108,14 +108,14 @@ ui_teal_module.teal_module <- function(id, modules, ..., depth = 0L) {
   # #teal-teal_modules-module-example_teal_module
   args <- c(list(id = ns("module")), modules$ui_args)
   ui_teal <- tags$div(
-    tags$div(
+    shinyjs::hidden(tags$div(
       id = ns("transform_failure_info"),
       class = "teal_validated",
       div(
-        class = "teal-output-warning",
-        "One of transformators failed. Please check its inputs."
+        "One of transformators failed. Please check its inputs.",
+        class = "teal-output-warning"
       )
-    ),
+    )),
     tags$div(
       id = ns("teal_module_ui"),
       tags$div(

--- a/R/module_teal_data.R
+++ b/R/module_teal_data.R
@@ -138,7 +138,8 @@ srv_validate_reactive_teal_data <- function(id, # nolint: object_length
     output$previous_failed <- renderUI({
       if (hide_validation_error()) {
         shinyjs::hide("validate_messages")
-        tags$div("One of previous transformators failed. Please check its inputs.", class = "teal-output-warning")
+        tags$div("One of previous transformators failed. Please check its inputs.",
+                 class = "teal-output-warning")
       } else {
         shinyjs::show("validate_messages")
         NULL

--- a/man/module_teal_module.Rd
+++ b/man/module_teal_module.Rd
@@ -12,13 +12,13 @@
 \alias{srv_teal_module.teal_module}
 \title{Calls all \code{modules}}
 \usage{
-ui_teal_module(id, modules, depth = 0L)
+ui_teal_module(id, modules, ...)
 
-\method{ui_teal_module}{default}(id, modules, depth = 0L)
+\method{ui_teal_module}{default}(id, modules, ...)
 
-\method{ui_teal_module}{teal_modules}(id, modules, depth = 0L)
+\method{ui_teal_module}{teal_modules}(id, modules, ..., depth = 0L)
 
-\method{ui_teal_module}{teal_module}(id, modules, depth = 0L)
+\method{ui_teal_module}{teal_module}(id, modules, ..., depth = 0L)
 
 srv_teal_module(
   id,
@@ -71,6 +71,8 @@ srv_teal_module(
 \code{teal_modules} object. These are the specific output modules which
 will be displayed in the \code{teal} application. See \code{\link[=modules]{modules()}} and \code{\link[=module]{module()}} for
 more details.}
+
+\item{...}{Other arguments depending on the method.}
 
 \item{depth}{(\code{integer(1)})
 number which helps to determine depth of the modules nesting.}


### PR DESCRIPTION
# Pull Request

Fixes #1514

By inserting the UI when the data is ready tabs do not appear and disappear in delayed data.
This PR modifies the `id`s in order to fully resolve the insertion and the specific module content is correctly inserted/loaded.

Also I've hidden a message about transformators failing, as the message can/is later shown if required. 

These changes currently broke tests on `test-teal_module.R` (>65) due to expected ids no longer matching, but sharing here first to make it easier to discuss the approach used. 

Besides the example app on the issue (with `teal_data_module()`) I also used this other app with just `teal_data` to make sure that it keeps working for other cases. 

<details><summary>Extra app</summary>
<p>

```r
app2 <- init(
  data = within(
    teal.data::teal_data(),
    {
      new_iris <- transform(iris, id = seq_len(nrow(iris)))
      new_mtcars <- transform(mtcars, id = seq_len(nrow(mtcars)))
    }
  ),
  modules = example_module()
)
shiny::shinyApp(ui = app2$ui, server = app2$server)
```

</p>
</details> 