### PR TITLE
Fix link to a renamed section

### DIFF
--- a/vignettes/including-data-in-teal-applications.Rmd
+++ b/vignettes/including-data-in-teal-applications.Rmd
@@ -43,7 +43,7 @@ library(teal)
 data <- teal_data(iris = iris, cars = mtcars)
 ```
 
-Note that `iris` and `cars` have been added to the `datanames` property of `data` (see [`datanames` property](#datanames)).
+Note that `iris` and `cars` have been added to the `datanames` property of `data` (see [`datanames` property](#teal_data-properties)).
 
 This is sufficient to run a `teal` app.
 


### PR DESCRIPTION
# Pull Request

Fixes #1508

Small issue about incorrect anchor to a section of the vignette (Or we might decide to remove the link completely).
