### PR TITLE
Naming

### DIFF
--- a/R/module_init_data.R
+++ b/R/module_init_data.R
@@ -93,7 +93,7 @@ srv_init_data <- function(id, data) {
   data_teal_report <- as.teal_report(data)
   if (!inherits(data, "teal_report")) {
     teal.reporter::report(data_teal_report) <- c(
-      teal.reporter::doc(),
+      teal.reporter::document(data_teal_report),
       "# Code preparation",
       teal.reporter::report(data_teal_report)
     )

--- a/R/teal_data_utils.R
+++ b/R/teal_data_utils.R
@@ -21,8 +21,8 @@ NULL
   checkmate::assert_class(data, "teal_data")
   if (length(code) && !identical(code, "")) {
     data@code <- c(data@code, code2list(code))
-    teal.reporter::report(data) <- c(
-      teal.reporter::report(data),
+    teal.reporter::document(data) <- c(
+      teal.reporter::document(data),
       "# Data filtering",
       teal.reporter::code_chunk(code)
     )
@@ -60,7 +60,7 @@ NULL
         c(x, this)
       }
     },
-    init = teal.reporter::doc(),
+    init = teal.reporter::teal_document(),
     x = report
   )
 }

--- a/R/teal_reporter.R
+++ b/R/teal_reporter.R
@@ -300,8 +300,8 @@ srv_add_reporter <- function(id, module_out, reporter) {
       req(module_out())
       if (is.reactive(module_out())) {
         req(module_out()())
-        if (inherits(module_out()(), "teal_report") || length(teal.reporter::report(module_out()()))) {
-          .collapse_subsequent_chunks(teal.reporter::report(module_out()()))
+        if (inherits(module_out()(), "teal_report") || length(teal.reporter::document(module_out()()))) {
+          .collapse_subsequent_chunks(teal.reporter::document(module_out()()))
         }
       }
     })
@@ -326,7 +326,7 @@ srv_add_reporter <- function(id, module_out, reporter) {
 disable_report <- function(x) {
   checkmate::assert_class(x, "teal_module")
   after(x, server = function(data) {
-    teal.reporter::report(data) <- teal.reporter::doc()
+    teal.reporter::document(data) <- teal.reporter::teal_document()
     NULL
   })
 }


### PR DESCRIPTION
Companion to https://github.com/insightsengineering/teal.reporter/pull/334
Consequence of changing naming convention for `teal_report` object.