### PR TITLE
Disable report when error

### DIFF
--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -404,9 +404,9 @@ srv_teal_module.teal_module <- function(id,
           module_out(.call_teal_module(modules, datasets, module_teal_data, reporter))
         }
       )
-    })
 
-    srv_add_reporter("add_reporter_wrapper", module_out, reporter)
+      srv_add_reporter("add_reporter_wrapper", module_out, reporter)
+    })
     module_out
   })
 }

--- a/R/teal_reporter.R
+++ b/R/teal_reporter.R
@@ -321,11 +321,7 @@ srv_add_reporter <- function(id, module_out, reporter) {
     })
 
     observeEvent(doc_out(), ignoreNULL = FALSE, {
-      if (inherits(doc_out(), "teal_card")) {
-        shinyjs::enable("reporter_add_container")
-      } else {
-        shinyjs::disable("reporter_add_container")
-      }
+      shinyjs::toggleState("reporter_add_container", condition = inherits(doc_out(), "teal_card"))
     })
   })
 }

--- a/R/teal_reporter.R
+++ b/R/teal_reporter.R
@@ -296,29 +296,37 @@ srv_add_reporter <- function(id, module_out, reporter) {
     return(FALSE)
   } # early exit
   moduleServer(id, function(input, output, session) {
-    doc_out <- reactive({
+    mod_out_r <- reactive({
       req(module_out())
       if (is.reactive(module_out())) {
-        req(module_out()())
-        if (inherits(module_out()(), "teal_report") || length(teal.reporter::teal_card(module_out()()))) {
-          .collapse_subsequent_chunks(teal.reporter::teal_card(module_out()()))
-        }
+        module_out()()
       }
     })
 
-    output$reporter_add_container <- renderUI({
-      req(doc_out())
-      tags$div(
-        class = "teal add-reporter-container",
-        teal.reporter::add_card_button_ui(session$ns("reporter_add"))
-      )
+    doc_out <- reactive({
+      teal_data_handled <- tryCatch(mod_out_r(), error = function(e) e)
+      if (inherits(teal_data_handled, "teal_report") && length(teal.reporter::teal_card(teal_data_handled))) {
+        .collapse_subsequent_chunks(teal.reporter::teal_card(teal_data_handled))
+      }
     })
 
-    add_document_button_srv(
-      "reporter_add",
-      reporter = reporter,
-      r_card_fun = doc_out
-    )
+    .call_once_when(!is.null(doc_out()), {
+      output$reporter_add_container <- renderUI({
+        tags$div(
+          class = "teal add-reporter-container",
+          teal.reporter::add_card_button_ui(session$ns("reporter_add"))
+        )
+      })
+      teal.reporter::add_card_button_srv("reporter_add", reporter = reporter, card_fun = doc_out)
+    })
+
+    observeEvent(doc_out(), ignoreNULL = FALSE, {
+      if (inherits(doc_out(), "teal_card")) {
+        shinyjs::enable("reporter_add_container")
+      } else {
+        shinyjs::disable("reporter_add_container")
+      }
+    })
   })
 }
 


### PR DESCRIPTION
When teal_module's server returns an error (validation error, qenv error etc.) teal.reporter-add button has no protection against it. This PR fixes following:
- To not display error received from a module
- To disable add-to-report-button when error occurs 
