### PR TITLE
Fix failing checks

### DIFF
--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -2407,6 +2407,7 @@ testthat::describe("srv_teal summary table", {
   })
 
   testthat::it("summary table displays MAE dataset added in transformators", {
+    testthat::skip_if_not_installed("MultiAssayExperiment")
     data <- within(teal.data::teal_data(), {
       iris <- iris
       mtcars <- mtcars

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -76,7 +76,7 @@ test_that("validate_app_title_tag works on validating the title tag", {
 })
 
 test_that("build_app_title builts a valid tag", {
-  valid_title_local <- build_app_title("title", "logo.png")
+  testthat::expect_warning(valid_title_local <- build_app_title("title", "logo.png"))
   valid_title_remote <- build_app_title("title", "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png") # nolint
   testthat::expect_silent(validate_app_title_tag(valid_title_local))
   testthat::expect_silent(validate_app_title_tag(valid_title_remote))


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #1546 

Somehow MultiAssayExperiment was installed on Windows but could not be loaded. 
From the [log of the action](https://github.com/r-universe/pharmaverse/actions/runs/15386329233/job/43285854035#step:6:1237):

```
L374: package 'MultiAssayExperiment' successfully unpacked and MD5 sums checked

...

L1233  • {MultiAssayExperiment} cannot be loaded (1):
L1234    'test-shinytest2-data_summary.R:91:5'
```
The failing test didn't have a `skip_if_not_installed("MultiAssayExperiment")`, which I added now.

In addition I noticed that there was a deprecation warning generated (once) by `build_app_title()` that wasn't captured. 
