### PR TITLE
chore: bump teal.logger dependency to 0.4.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Imports:
     shinyjs,
     stats,
     teal.code (>= 0.6.1),
-    teal.logger (>= 0.3.2.9001),
+    teal.logger (>= 0.4.0),
     teal.reporter (>= 0.4.0.9004),
     teal.widgets (>= 0.4.3.9001),
     tools,
@@ -79,7 +79,6 @@ VignetteBuilder:
 RdMacros:
     lifecycle
 Remotes:
-    insightsengineering/teal.logger@main,
     insightsengineering/teal.reporter@main,
     insightsengineering/teal.slice@main,
     insightsengineering/teal.widgets@main


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.logger (>= 0.4.0) and removes it from Remotes.