### PR TITLE
Module label

### DIFF
--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -76,6 +76,16 @@ ui_teal_modules_nav <- function(id, modules) {
   )
   nav_buttons <- ui_teal_modules_nav_dropdown(id = ns("nav"), modules = modules, active_module_id)
   tab_content <- ui_teal_module(id = ns("nav"), modules = modules, active_module_id = active_module_id)
+
+  count_modules <- function(x) {
+    if (inherits(x, "teal_module")) {
+      1L
+    } else if (inherits(x, "teal_modules")) {
+      sum(vapply(x$children, count_modules, integer(1L)))
+    }
+  }
+  module_count <- count_modules(modules)
+  dropdown_label <- sprintf("Module%s (%d)", ifelse(module_count > 1, "s", ""), module_count)
   tags$div(
     class = "teal-modules-wrapper",
     tags$ul(
@@ -87,7 +97,7 @@ ui_teal_modules_nav <- function(id, modules) {
         class = "dropdown nav-item-custom",
         .dropdown_button(
           id = NULL,
-          label = "Module",
+          label = dropdown_label,
           icon = "diagram-3-fill",
           add_dropdown = TRUE
         ),


### PR DESCRIPTION
Target: `redesign-ui-ux@main` branch

### Changes description

- Add count number to the "Module" navigation label

### Screenshots

#### More than 1 module

<img width="429" height="182" alt="image" src="https://github.com/user-attachments/assets/b427e118-5bc1-4d3f-b811-90936b5bd7ba" />

<img width="666" height="408" alt="image" src="https://github.com/user-attachments/assets/364e8353-9bc9-45b8-99dc-fc876ec8e999" />

#### 1 module

<img width="666" height="408" alt="image" src="https://github.com/user-attachments/assets/c124786d-e180-4294-a9d4-7c9a720d86aa" />


