### PR TITLE
obtain a named list from environment

### DIFF
--- a/R/module_init_data.R
+++ b/R/module_init_data.R
@@ -95,10 +95,9 @@ srv_init_data <- function(id, data) {
     c(
       list(code = trimws(c(teal.code::get_code(data), hashes), which = "right")),
       list(join_keys = teal.data::join_keys(data)),
-      as.list(data)
+      as.list(data, all.names = TRUE)
     )
   )
-
   tdata@verified <- data@verified
   tdata
 }

--- a/R/module_init_data.R
+++ b/R/module_init_data.R
@@ -95,12 +95,7 @@ srv_init_data <- function(id, data) {
     c(
       list(code = trimws(c(teal.code::get_code(data), hashes), which = "right")),
       list(join_keys = teal.data::join_keys(data)),
-      sapply(
-        names(data),
-        teal.code::get_var,
-        object = data,
-        simplify = FALSE
-      )
+      as.list(data)
     )
   )
 


### PR DESCRIPTION
On teal.code@main `get_var` is hard-deprecated. Here is the easier way to obtain qenv objects as a list