### PR TITLE
dont display data button when once = TRUE

### DIFF
--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -224,16 +224,11 @@ srv_teal <- function(id, data, modules, filter = teal_slices()) {
       )
 
       if (isTRUE(attr(data, "once"))) {
+        # when once = TRUE we pull data once and then remove data button and a modal
+        shiny::removeUI(selector = sprintf(".teal.expand-button:has(#%s)", session$ns("open_teal_data_module_ui")))
         observeEvent(data_signatured(), once = TRUE, {
           logger::log_debug("srv_teal@2 removing data tab.")
-          # when once = TRUE we pull data once and then remove data tab
           shiny::removeModal()
-          shiny::removeUI(
-            selector = sprintf(
-              ".teal.expand-button:has(#%s)",
-              session$ns("teal_data_module_ui")
-            )
-          )
         })
       }
     } else {


### PR DESCRIPTION


<img width="804" height="158" alt="Skärmavbild 2025-08-14 kl  10 50 17" src="https://github.com/user-attachments/assets/6ea58403-ea6d-4dfe-ada6-b0f9bab8f4ca" />

When `once = TRUE` data button shouldn't be even shown

<details>
<summary> app </summary>

```r
pkgload::load_all("teal")
library(teal)

data <- teal_data_module(
  once = TRUE,
  ui = function(id) {
    ns <- NS(id)
    tagList(
      numericInput(ns("obs"), "Number of observations to show", 1000),
      actionButton(ns("submit"), label = "Submit")
    )
  },
  server = function(id, ...) {
    moduleServer(id, function(input, output, session) {
      logger::log_trace("example_module_transform2 initializing.")
      eventReactive(input$submit, {
        data <- teal_data(a = NULL) |>
          within(
            {
              logger::log_trace("Loading data")
              ADSL <- head(teal.data::rADSL, n = n)
              ADTTE <- teal.data::rADTTE
              iris <- iris
              .iris_raw <- iris
              CO2 <- CO2
              factors <- names(Filter(isTRUE, vapply(CO2, is.factor, logical(1L))))
              CO2[factors] <- lapply(CO2[factors], as.character)
            },
            n = as.numeric(input$obs)
          )
        join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
        data
      })
    })
  }
)

app <- teal::init(
  data = data,
  modules = modules(
    example_module("all", datanames = "all")
  )
)

runApp(app)

```

</details>