### PR TITLE
chore: bump teal.code dependency to 0.7.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Imports:
     rlang (>= 1.0.0),
     shinyjs,
     stats,
-    teal.code (>= 0.6.1),
+    teal.code (>= 0.7.0),
     teal.logger (>= 0.4.0),
     teal.reporter (>= 0.4.0.9005),
     teal.widgets (>= 0.4.3.9001),


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.code (>= 0.7.0) and removes it from Remotes.