### PR TITLE
chore: bump teal.reporter dependency to 0.5.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Imports:
     stats,
     teal.code (>= 0.6.1),
     teal.logger (>= 0.4.0),
-    teal.reporter (>= 0.7.0),
+    teal.reporter (>= 0.5.0),
     teal.widgets (>= 0.4.3.9001),
     tools,
     utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Imports:
     stats,
     teal.code (>= 0.6.1),
     teal.logger (>= 0.4.0),
-    teal.reporter (>= 0.4.0.9005),
+    teal.reporter (>= 0.7.0),
     teal.widgets (>= 0.4.3.9001),
     tools,
     utils
@@ -80,7 +80,6 @@ VignetteBuilder:
 RdMacros:
     lifecycle
 Remotes:
-    insightsengineering/teal.reporter@main,
     insightsengineering/teal.slice@main,
     insightsengineering/teal.widgets@main
 Config/Needs/verdepcheck: rstudio/shiny, insightsengineering/teal.data,

--- a/man/check_reactive.Rd
+++ b/man/check_reactive.Rd
@@ -18,7 +18,7 @@ assert_reactive(
 )
 }
 \arguments{
-\item{x}{[any]\cr
+\item{x}{[\code{any}]\cr
 Object to check.}
 
 \item{null.ok}{[\code{logical(1)}]\cr


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.reporter (>= 0.5.0) and removes it from Remotes.