### PR TITLE
If reporter was provided, reuse it in srv_teal

### DIFF
--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -239,13 +239,16 @@ srv_teal <- function(id, data, modules, filter = teal_slices(), reporter = teal.
         ui = tags$div(validate_ui)
       )
     }
-
     if (!is.null(reporter)) {
       shinyjs::show("reporter_menu_container")
     } else {
       removeUI(selector = sprintf("#%s", session$ns("reporter_menu_container")))
     }
-    reporter <- teal.reporter::Reporter$new()$set_id(attr(filter, "app_id"))
+    if (!is.null(reporter)) {
+      reporter$set_id(attr(filter, "app_id"))
+    } else {
+      reporter <- teal.reporter::Reporter$new()$set_id(attr(filter, "app_id"))
+    }
     teal.reporter::preview_report_button_srv("preview_report", reporter)
     teal.reporter::report_load_srv("load_report", reporter)
     teal.reporter::download_report_button_srv(id = "download_report", reporter = reporter)


### PR DESCRIPTION
Tested with 

- https://github.com/insightsengineering/teal.reporter/discussions/388

Fixes this point

<img width="599" height="158" alt="image" src="https://github.com/user-attachments/assets/78edaae1-13c1-4afd-9335-7d25c292470f" />

from this comment https://github.com/insightsengineering/nestdevs-tasks/issues/106#issuecomment-3241994959

Previously we created new reporter when setting id, instead of reusing the reporter.
Now you are able to pass custom reporter that is used across the app.