### PR TITLE
Add option to move sidebar to the right

### DIFF
--- a/R/module_nested_tabs.R
+++ b/R/module_nested_tabs.R
@@ -234,6 +234,7 @@ srv_teal_module <- function(id,
             sidebar = bslib::sidebar(
               id = ns("teal_module_sidebar"),
               class = "teal-sidebar",
+              position = getOption("teal.sidebar.position", "left"),
               width = getOption("teal.sidebar.width", 250),
               tags$div(
                 tags$div(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,6 +5,8 @@
     teal.show_js_log = FALSE,
     teal.lockfile.mode = "auto",
     shiny.sanitize.errors = FALSE,
+    teal.sidebar.position = "left",
+    teal.sidebar.width = 250,
     teal.reporter.nav_buttons = c("preview", "download", "load", "reset")
   )
 

--- a/vignettes/teal-options.Rmd
+++ b/vignettes/teal-options.Rmd
@@ -98,6 +98,11 @@ Default: `"auto"`.
 
 To read more about lockfile usage creation check `?teal::module_teal_lockfile`.
 
+### `teal.sidebar.position` (`character`)
+This sets the position of the sidebar in the teal app. Possible values are `"left"` and `"right"`.
+
+Default: `left`
+
 ### `teal.sidebar.width` (`numeric`)
 
 This sets the sidebar width in pixels in the teal app.


### PR DESCRIPTION
Adds a new option `teal.sidebar.position` which can move the main teal sidebar to left/right with left being the default when nothing is specified.

```
devtools::load_all("teal")
options(teal.sidebar.position = "right")
init(data = teal_data(iris = head(iris)), modules = example_module()) |> runApp()
```
<img width="1712" height="532" alt="image" src="https://github.com/user-attachments/assets/6aa54635-20c7-4005-8628-94435aa42a17" />
