### PR TITLE
delete wrong @return

### DIFF
--- a/R/modules.R
+++ b/R/modules.R
@@ -82,10 +82,7 @@ setOldClass("teal_modules")
 #' @return
 #' `module()` returns an object of class `teal_module`.
 #'
-#' `modules()` returns a `teal_modules` object which contains following fields:
-#' - `label`: taken from the `label` argument.
-#' - `children`: a list containing objects passed in `...`. List elements are named after
-#' their `label` attribute converted to a valid `shiny` id.
+#' `modules()` returns an object of class `teal_modules`.
 #'
 #' @name teal_modules
 #' @aliases teal_module

--- a/man/teal_modules.Rd
+++ b/man/teal_modules.Rd
@@ -109,12 +109,7 @@ format.teal_modules(). Determines whether to show "TEAL ROOT" header}
 \value{
 \code{module()} returns an object of class \code{teal_module}.
 
-\code{modules()} returns a \code{teal_modules} object which contains following fields:
-\itemize{
-\item \code{label}: taken from the \code{label} argument.
-\item \code{children}: a list containing objects passed in \code{...}. List elements are named after
-their \code{label} attribute converted to a valid \code{shiny} id.
-}
+\code{modules()} returns an object of class \code{teal_modules}.
 }
 \description{
 Create a nested tab structure to embed modules in a \code{teal} application.


### PR DESCRIPTION
The description is wrong after latest release. I'm removing the description of the `teal_modules` fields as it might inspire users to use it.