### PR TITLE
handle show R code button visibility with `verbatim_popup_srv`

### DIFF
--- a/R/module_source_code.R
+++ b/R/module_source_code.R
@@ -49,13 +49,13 @@ srv_source_code <- function(id, module_out) {
 
     reason_r <- reactive({
       if (is.null(mod_out_r())) {
-        "No source code is available from this module."
+        "No source code is available for this module."
       } else if (isFALSE(attr(mod_out_r(), "teal.enable_src"))) {
-        "The show source code functionality is disabled for this module."
+        "The source code functionality is disabled for this module."
       } else if (inherits(mod_out_r(), "error")) {
         "The module returned an error, check it for errors."
       } else if (is.null(code_out())) {
-        "The module does not support source code functionality"
+        "The module does not support source code functionality."
       }
     })
 
@@ -73,12 +73,11 @@ srv_source_code <- function(id, module_out) {
         }
       })
 
-      observeEvent(reason_r(), ignoreNULL = FALSE, {
-        shinyjs::toggleState("source_code_wrapper", condition = is.null(reason_r()))
-      })
-
       verbatim_popup_srv(
-        id = "source_code", verbatim_content = code_out, title = "Show R Code"
+        id = "source_code", 
+        verbatim_content = code_out, 
+        title = "Show R Code",
+        disabled = reactive(!is.null(reason_r()))
       )
     }
   })


### PR DESCRIPTION
Fixes 

- https://github.com/insightsengineering/teal/issues/1614

# The Root Cause

The `verbatim_popup_srv` function creates its own `observeEvent` that watches a disabled reactive parameter and calls `shinyjs::disable("button")` or `shinyjs::enable("button")` on the actual button. This was overriding our attempts to disable the wrapper element.

# The Solution

Instead of trying to disable the wrapper element with `shinyjs::disable/toggle("source_code_wrapper")`, I passed the disabled reactive directly to `verbatim_popup_srv`


--------------------------------------------------------------------------------------------------------------------------

# Testing

You can test with `tm_data_table`

```r

devtools::load_all("teal.code")
devtools::load_all("teal.data")
devtools::load_all("teal.widgets")
devtools::load_all("teal.reporter")
devtools::load_all("teal.slice")
devtools::load_all("teal.transform")
devtools::load_all("teal")
devtools::load_all("teal.modules.general")

# ##########################################
#
#   _             _      _       _
#  | |           | |    | |     | |
#  | |_ ___  __ _| |  __| | __ _| |_ __ _
#  | __/ _ \/ _` | | / _` |/ _` | __/ _` |
#  | ||  __/ (_| | || (_| | (_| | || (_| |
#   \__\___|\__,_|_| \__,_|\__,_|\__\__,_|
#                ______
#               |______|
#
#  teal_data
# #########################################

data <- teal_data(join_keys = default_cdisc_join_keys[c("ADSL", "ADRS")])
data <- within(data, {
  require(nestcolor)
  ADSL <- rADSL
  ADRS <- rADRS
})

# For tm_outliers
fact_vars_adsl <- names(Filter(isTRUE, sapply(data[["ADSL"]], is.factor)))
vars <- choices_selected(variable_choices(data[["ADSL"]], fact_vars_adsl))

# For tm_g_distribution

vars1 <- choices_selected(
  variable_choices(data[["ADSL"]], c("ARM", "COUNTRY", "SEX")),
  selected = NULL
)


init(
  data = data,
  modules = modules(
    # ################################################
    #
    #       _       _         _        _     _
    #      | |     | |       | |      | |   | |
    #    __| | __ _| |_ __ _ | |_ __ _| |__ | | ___
    #   / _` |/ _` | __/ _` || __/ _` | '_ \| |/ _ \
    #  | (_| | (_| | || (_| || || (_| | |_) | |  __/
    #   \__,_|\__,_|\__\__,_| \__\__,_|_.__/|_|\___|
    #                     ______
    #                    |______|
    #
    #  data_table
    # ###############################################
    tm_data_table(
      variables_selected = list(
        iris = c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
      ),
      dt_args = list(caption = "IRIS Table Caption")
    )
  )
) |> shiny::runApp()

```

How it looks now, the button is disabled

<img width="950" height="362" alt="image" src="https://github.com/user-attachments/assets/f367b0b0-6d54-48b7-afdb-50f55a6f81de" />
