### PR TITLE
setup `.devcontainer`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   // "forwardPorts": [],
   
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "apt-get update && apt-get install -y python3-pip pipx && pipx ensurepath && pipx install pre-commit",
+  "postCreateCommand": "apt-get update && apt-get install -y python3-pip pipx && pipx ensurepath && pipx install pre-commit && pip install -U radian && (which radian > /dev/null 2>&1 && ln -sf $(which radian) /usr/local/bin/radian || true)",
   
   // Configure tool-specific properties.
   "customizations": {


### PR DESCRIPTION
An attempt to setup `.devcontainer` structure so that you can use pre-defined Docker image with R installed And potentially many more R packages LOCALLY in your VS Code or for interactive live github copilot coding environment

Closes
- https://github.com/insightsengineering/coredev-tasks/issues/678

Allows to open VS Code / Cursor in a pre-created docker image that is also used during CI/CD testing


---------------------------------------------------------------------------------

# Steps to reproduce - locally in VS Code / Cursor

- Open VS Code / Cursor on this branch
- Launch Docker Desktop, or be sure Docker is running on your machine
- Click in the notification to reopen with devcontainer

<img width="400" height="100" alt="image" src="https://github.com/user-attachments/assets/ab08fed1-3a2e-43c5-b004-e2b55b72b044" />

- On VS Code it looks like this -> right bottom corner

<img width="956" height="592" alt="image" src="https://github.com/user-attachments/assets/4b9c57f0-6d29-41c0-8ec7-32502dffeec9" />


- The image will be pulled (if it was not pulled before)


<img width="470" height="344" alt="image" src="https://github.com/user-attachments/assets/69b3d761-7fbf-4d4d-a5ec-92ba5efdffa6" />

- Once the image is pulled, the docker container is started

<img width="461" height="343" alt="image" src="https://github.com/user-attachments/assets/1abe2e2f-ea19-455a-8bf5-4ef054d8de1a" />

- Note that this container has 9 GBs

<img width="947" height="336" alt="image" src="https://github.com/user-attachments/assets/bc232f43-f4f5-49de-ba84-219b2993e88b" />

- Now, when opening a terminal, you should be inside the docker container

<img width="464" height="209" alt="image" src="https://github.com/user-attachments/assets/3e018a58-59e7-45e4-b8b7-7af37333b7be" />

- You can check the structure of the project inside the container, and you can obviously run R

<img width="463" height="305" alt="image" src="https://github.com/user-attachments/assets/0c187fef-b040-4e8a-8cd6-91236914d82c" />

- You can see brand new packages from CRAN - this is our CI setup

<img width="467" height="449" alt="image" src="https://github.com/user-attachments/assets/9ca0a46b-963d-480f-a2f0-699a7449ba75" />

- For the development setup, you would need to install development versions of packages on your own
<img width="466" height="469" alt="image" src="https://github.com/user-attachments/assets/6628166d-effc-4173-9894-bc15ede760c1" />

- You can also see it created a new branch called `devcontainer` for you to work

<img width="218" height="287" alt="image" src="https://github.com/user-attachments/assets/6d7241a6-a79f-4118-80c9-25304745f7a4" />

- It also created a Workspace for you, that you can always close, when you are done

<img width="290" height="402" alt="image" src="https://github.com/user-attachments/assets/c1b3f243-c6af-4010-ad15-bfbd33f8cd98" />

- Here you can close

<img width="284" height="376" alt="image" src="https://github.com/user-attachments/assets/a5a0cf92-8d00-49ab-b120-54bf892c0e55" />

- And then you can open again by selecting this workspace

<img width="677" height="425" alt="image" src="https://github.com/user-attachments/assets/28f5e2e4-020c-4327-b9d6-9cb1548d58b2" />

- Final note: by default all folders from your current workspace are added to the container: 
    - this is specified by `"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"` in `.devcontainer.json`
    - but the devcontainer needs to be on the same level as all folder like below
 
<img width="227" height="508" alt="image" src="https://github.com/user-attachments/assets/af09cc17-1d73-42bd-8b94-4f3639a4aa13" />

- So it opens the devcontainer will all folders included

<img width="629" height="272" alt="image" src="https://github.com/user-attachments/assets/2111014b-f372-4359-807e-f94b034cb13b" />

- Lastly, you can see that each Remote Session with devcontainer starts a docker container

<img width="950" height="386" alt="image" src="https://github.com/user-attachments/assets/df4ef271-3432-40d5-aa3e-d3252e8d4ece" />


---------------------------------------------------------------------------------

# Steps to reproduce - remotely in GitHub Codespaces

- In project main view, click Code -> Create codespace on devcontainer

<img width="840" height="463" alt="image" src="https://github.com/user-attachments/assets/1379f561-2f36-468d-9822-c9bd78b5bcfb" />

- You should see a page where the codespace is being created for you

<img width="952" height="535" alt="image" src="https://github.com/user-attachments/assets/d7104690-6b0e-464e-b169-662551265c36" />

- First Codespace creation is slow with this docker container (9 GB), but once it's created then you can always jump off and on
- This is how it looks when it's finally launched
<img width="958" height="530" alt="image" src="https://github.com/user-attachments/assets/3e2e7fb0-4e98-494a-9124-de3244096565" />
- It has R and teal from CRAN
<img width="946" height="530" alt="image" src="https://github.com/user-attachments/assets/1731e7f3-4cde-41d0-aef1-ea2b399c824a" />

- You can always open the codespace back again from project website
<img width="943" height="526" alt="image" src="https://github.com/user-attachments/assets/0c459102-c544-42fa-90cb-48355aee2968" />
- And this is how you stop the codespace
<img width="611" height="372" alt="image" src="https://github.com/user-attachments/assets/c3c6f54e-fb4c-43c3-951b-62e55d9b2017" />
