### PR TITLE
Improve test coverage in `module_teal_data`

### DIFF
--- a/tests/testthat/test-module_teal_data.R
+++ b/tests/testthat/test-module_teal_data.R
@@ -149,11 +149,13 @@ testthat::describe("srv_teal with teal_data_module (indirectly tests srv_teal_da
         id = "test",
         data = teal_data_module(
           ui = function(id) tags$div("Data Module UI"),
-          server = function(id) reactive(teal.data::teal_data(
-            iris = iris,
-            mtcars = mtcars,
-            join_keys = teal.data::join_keys(teal.data::join_key("iris", "iris", "Species"))
-          ))
+          server = function(id) {
+            reactive(teal.data::teal_data(
+              iris = iris,
+              mtcars = mtcars,
+              join_keys = teal.data::join_keys(teal.data::join_key("iris", "iris", "Species"))
+            ))
+          }
         ),
         modules = modules(create_test_module()),
         filter = teal_slices(),


### PR DESCRIPTION
Alternative for https://github.com/insightsengineering/teal/pull/1625

```r
> devtools::test_active_file()
[INFO] 2025-10-10 18:12:51.6685 pid:21188 token:[] teal 
You are using teal version 1.0.0.9011

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 70 ]
```