### PR TITLE
Restore reporter cards

### DIFF
--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -130,6 +130,10 @@ srv_teal <- function(id, data, modules, filter = teal_slices(), reporter = teal.
       shinyjs::showLog()
     }
 
+    session$onBookmark(function(state) {
+      logger::log_debug("srv_teal@onBookmark: storing report cards")
+      state$values$report_cards <- shiny::isolate(reporter$get_cards())
+    })
     # set timezone in shiny app
     # timezone is set in the early beginning so it will be available also
     # for `DDL` and all shiny modules
@@ -246,6 +250,11 @@ srv_teal <- function(id, data, modules, filter = teal_slices(), reporter = teal.
       {
         if (!is.null(reporter)) {
           reporter$set_id(attr(filter, "app_id"))
+          report_cards <- restoreValue(session$ns("report_cards"), NULL)
+          if (length(report_cards)) {
+            reporter$reset()
+            reporter$append_cards(report_cards)
+          }
           teal.reporter::preview_report_button_srv("preview_report", reporter)
           teal.reporter::report_load_srv("load_report", reporter)
           teal.reporter::download_report_button_srv(id = "download_report", reporter = reporter)

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -2735,3 +2735,147 @@ testthat::describe("teal.data code with a function defined", {
     )
   })
 })
+
+testthat::describe("teal-reporter", {
+  it("Clicking Add Card adds a card to the reporter", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = within(
+          teal.data::teal_data(),
+          iris <- iris
+        ),
+        modules = modules(
+          module("module_1", server = function(id, data) data)
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_module_id` = "module_1")
+        session$flushReact()
+        testthat::expect_length(reporter$get_cards(), 0)
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_report_card_button` = 1)
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_card_ok` = 1)
+        testthat::expect_length(reporter$get_cards(), 1)
+      }
+    )
+  })
+
+  it("Card added to the report contains ## Data preparation element", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = within(
+          teal.data::teal_data(),
+          iris <- iris
+        ),
+        modules = modules(
+          module("module_1", server = function(id, data) data)
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_module_id` = "module_1")
+        session$flushReact()
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_report_card_button` = 1)
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_card_ok` = 1)
+        testthat::expect_contains(reporter$get_cards()[[1]], "## Data preparation")
+      }
+    )
+  })
+
+  it("Card added to the report contains concatenated code_chunks", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = within(
+          teal.data::teal_data(),
+          iris <- iris
+        ),
+        modules = modules(
+          module("module_1", server = function(id, data) data)
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_module_id` = "module_1")
+        session$flushReact()
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_report_card_button` = 1)
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_card_ok` = 1)
+        testthat::expect_identical(
+          reporter$get_cards()[[1]][[2]],
+          teal.reporter::code_chunk(
+            "iris <- iris\n.raw_data <- list2env(list(iris = iris))\nlockEnvironment(.raw_data) # @linksto .raw_data"
+          )
+        )
+      }
+    )
+  })
+
+  it("Card added to the report contains elements added in a module", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = within(
+          teal.data::teal_data(),
+          iris <- iris
+        ),
+        modules = modules(
+          module("module_1", server = function(id, data) reactive(within(data(), iris2 <- iris)))
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_module_id` = "module_1")
+        session$flushReact()
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_report_card_button` = 1)
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_card_ok` = 1)
+        testthat::expect_identical(
+          reporter$get_cards()[[1]][[2]],
+          teal.reporter::code_chunk(c(
+            "iris <- iris",
+            ".raw_data <- list2env(list(iris = iris))",
+            "lockEnvironment(.raw_data) # @linksto .raw_data",
+            "iris2 <- iris"
+          ))
+        )
+      }
+    )
+  })
+
+  it("Card added to the report contains Filter settings section, teal-slices-yaml and code if filters are set", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = within(
+          teal.data::teal_data(),
+          iris <- iris
+        ),
+        modules = modules(
+          module("module_1", server = function(id, data) data)
+        ),
+        filter = teal_slices(
+          teal_slice(dataname = "iris", varname = "Species", selected = "setosa")
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_module_id` = "module_1")
+        session$flushReact()
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_report_card_button` = 1)
+        session$setInputs(`teal_modules-nav-module_1-add_reporter_wrapper-reporter_add-add_card_ok` = 1)
+        testthat::expect_contains(
+          reporter$get_cards()[[1]],
+          c(
+            "### Filter settings",
+            teal.reporter::code_chunk(
+              "- Dataset name: iris\n  Variable name: Species\n  Selected Values: setosa\n",
+              lang = "filters"
+            ),
+            teal.reporter::code_chunk("iris <- dplyr::filter(iris, Species == \"setosa\")")
+          )
+        )
+      }
+    )
+  })
+})


### PR DESCRIPTION
Closes
- insightsengineering/teal.reporter#424 
- insightsengineering/teal.reporter/issues/352

In this PR:
- Reporter restorable with bookmarking (please follow instructions in the issue to reproduce).
- Some tests added to test reporter in teal
- Size of the bookmarking-files minimal 👍 (`tree --du -h shiny_bookmarks`)  
<img width="473" height="100" alt="Skärmavbild 2025-10-15 kl  08 33 28" src="https://github.com/user-attachments/assets/3627f489-208e-4ed3-ada5-20c2a7f29bc3" />
