### PR TITLE
docs: update documentation with new teal.reporter option

### DIFF
--- a/vignettes/teal-options.Rmd
+++ b/vignettes/teal-options.Rmd
@@ -158,7 +158,7 @@ list(
 
 ###  `teal.reporter.max_request_size` (`numeric`)
 
-It allows controlling the maximum size allowed for a `shiny::fileInput`. Intented to allow for larger file sizes when a big report file is uploaded.
+Allows to control the maximum size of a `shiny::fileInput`. Meant for large report file uploads.
 Default: `10 * 1024^2` which stands for 10MB.
 ### `teal.show_src` (`logical`)
 


### PR DESCRIPTION
This is a documentation update on the options vignetter related with [this comment](https://github.com/insightsengineering/teal.reporter/pull/437#discussion_r2459564682) on a [PR](https://github.com/insightsengineering/teal.reporter/pull/437) for teal.reporter that allow for larger than default 5MB for file inputs, which was common in `teal.reporter` report files.
