### PR TITLE
Modify Copilot setup to use native R installation

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -2,21 +2,31 @@ name: Copilot Agent Setup
 
 # Configure the environment for GitHub Copilot coding agent
 # This ensures R is available when the agent works on this repository
-# Uses the same Docker image as the CI/CD for consistency
+# Uses native R installation (containers may cause compatibility issues with Copilot's setup)
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/insightsengineering/rstudio:latest
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: 1
 
       - name: Verify R installation
         run: |


### PR DESCRIPTION
Updated the GitHub Actions workflow to use native R installation instead of a Docker container, ensuring better compatibility for Copilot's setup. Added permissions for repository access and included steps for setting up R and installing dependencies.

Our containers, and other Rocker containers are missing tools that Copilot expects, so it's better to go with a native environment where we install R and R dependencies on our own.

Part of 
- https://github.com/insightsengineering/coredev-tasks/issues/694