### PR TITLE
Fixes integration tests

### DIFF
--- a/tests/testthat/test-reporter_previewer_module.R
+++ b/tests/testthat/test-reporter_previewer_module.R
@@ -1,4 +1,6 @@
 testthat::describe("reporter_previewer_module", {
+  withr::local_options("lifecycle_verbosity" = "quiet")
+
   testthat::it("returns teal_module with previewer class", {
     module <- reporter_previewer_module(label = "test")
     testthat::expect_s3_class(module, "teal_module")

--- a/tests/testthat/test-shinytest2-show-rcode.R
+++ b/tests/testthat/test-shinytest2-show-rcode.R
@@ -36,8 +36,8 @@ testthat::test_that("e2e: Module with 'Show R Code' has modal with two dismiss a
   )
 
   # There are two Dismiss buttons with similar id and the same label.
-  buttons_text <- app$get_text("#shiny-modal button")
-  testthat::expect_setequal(buttons_text, trimws(c("Dismiss", "Copy to Clipboard", "Dismiss", "Copy to Clipboard")))
+  buttons_text <- trimws(app$get_text("#shiny-modal button"))
+  testthat::expect_setequal(buttons_text, c("Dismiss", "Copy to Clipboard", "Dismiss", "Copy to Clipboard"))
   app$stop()
 })
 


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

- Quiet verbosity of `reporter_previewer_module` deprecation message
- Update test to shiny new version that outputs elements with whitespace
