### PR TITLE
defaults to teal_data_module

### DIFF
--- a/R/teal_data_module.R
+++ b/R/teal_data_module.R
@@ -77,7 +77,14 @@
 #' @seealso [`teal.data::teal_data-class`], [teal.code::qenv()]
 #'
 #' @export
-teal_data_module <- function(ui, server, label = "data module", once = TRUE) {
+teal_data_module <- function(ui = function(id) NULL,
+                             server = function(id) {
+                               moduleServer(id, function(input, output, session) {
+                                 reactive(teal.data::teal_data())
+                               })
+                             },
+                             label = "data module",
+                             once = TRUE) {
   checkmate::assert_function(ui, args = "id", nargs = 1)
   checkmate::assert_function(server, args = "id", nargs = 1)
   checkmate::assert_string(label)

--- a/man/teal_data_module.Rd
+++ b/man/teal_data_module.Rd
@@ -10,7 +10,17 @@
 \alias{within.teal_data_module}
 \title{Data module for \code{teal} applications}
 \usage{
-teal_data_module(ui, server, label = "data module", once = TRUE)
+teal_data_module(
+  ui = function(id) NULL,
+  server = function(id) {
+     moduleServer(id, function(input, output, session) {
+      
+      reactive(teal.data::teal_data())
+     })
+ },
+  label = "data module",
+  once = TRUE
+)
 
 \S4method{eval_code}{teal_data_module}(object, code)
 

--- a/tests/testthat/test-module_teal.R
+++ b/tests/testthat/test-module_teal.R
@@ -152,6 +152,23 @@ testthat::describe("srv_teal arguments", {
       "Must be a reactive"
     )
   })
+
+
+  testthat::it("app works with default teal_data_module", {
+    testthat::expect_no_error(
+      shiny::testServer(
+        app = srv_teal,
+        args = list(
+          id = "test",
+          data = teal_data_module(),
+          modules = modules(example_module())
+        ),
+        expr = {
+          session$flushReact()
+        }
+      )
+    )
+  })
 })
 
 testthat::describe("srv_teal teal_modules", {
@@ -261,6 +278,24 @@ testthat::describe("srv_teal teal_modules", {
         session$setInputs(`teal_modules-active_module_id` = "module_2")
         testthat::expect_identical(modules_output$module_1(), 101L)
         testthat::expect_identical(modules_output$module_2(), 102L)
+      }
+    )
+  })
+
+  testthat::it("are called once their tab is selected with default (empty) teal_data_module", {
+    shiny::testServer(
+      app = srv_teal,
+      args = list(
+        id = "test",
+        data = teal_data_module(),
+        modules = modules(
+          module("module_1", server = function(id, data) 101L),
+          module("module_2", server = function(id, data) 102L)
+        )
+      ),
+      expr = {
+        session$setInputs(`teal_modules-active_module_id` = "module_1")
+        testthat::expect_identical(modules_output$module_1(), 101L)
       }
     )
   })


### PR DESCRIPTION
No issue - small improvement to be able to do any of these:

```r
tdm <- teal_data_module()
app <- init(data = tdm, modules = example_module())
shinyApp(app$ui, app$server)
```

or

```r
tdm <- teal_data_module(ui = function(id) div("my awesome ui"))
app <- init(data = tdm, modules = example_module())
shinyApp(app$ui, app$server)
```

or 

`` `r
tdm <- teal_data_module(
  server = function(id) {
    moduleServer(id, function(input, output, session) { 
      reactive(teal.data::teal_data(iris = iris)
    }
)
app <- init(data = tdm, modules = example_module())
shinyApp(app$ui, app$server)
```


