### PR TITLE
remove remotes field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,8 +79,6 @@ VignetteBuilder:
     rmarkdown
 RdMacros:
     lifecycle
-Remotes:
-    insightsengineering/teal.slice@main
 Config/Needs/verdepcheck: rstudio/shiny, insightsengineering/teal.data,
     insightsengineering/teal.slice, mllg/checkmate, jeroen/jsonlite,
     r-lib/lifecycle, daroczig/logger, r-lib/mirai, r-lib/cli,


### PR DESCRIPTION
Removing remotes field since teal.slice 0.8.0 made it to CRAN.