### PR TITLE
Change .default_teal_bslib_theming from object to function

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -26,17 +26,13 @@ get_client_timezone <- function(ns) {
 #' Set the default bslib theme for teal apps
 #' @noRd
 #' @keywords internal
-.default_teal_bslib_theming <- bslib::bs_theme(`font-size-base` = "0.875rem")
+.default_teal_bslib_theming <- function() bslib::bs_theme(`font-size-base` = "0.875rem")
 
 #' Resolve the expected bootstrap theme
 #' @noRd
 #' @keywords internal
 get_teal_bs_theme <- function() {
-  bs_theme <- getOption("teal.bs_theme")
-
-  if (is.null(bs_theme)) {
-    bs_theme <- .default_teal_bslib_theming
-  }
+  bs_theme <- getOption("teal.bs_theme", default = .default_teal_bslib_theming())
 
   if (!checkmate::test_class(bs_theme, "bs_theme")) {
     warning(
@@ -44,7 +40,7 @@ get_teal_bs_theme <- function() {
       checkmate::check_class(bs_theme, "bs_theme"),
       ". The default bslib Bootstrap theme will be used."
     )
-    bs_theme <- .default_teal_bslib_theming
+    bs_theme <- .default_teal_bslib_theming()
   }
 
   bs_theme

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,7 +10,7 @@
     teal.reporter.nav_buttons = c("preview", "download", "load", "reset"),
     teal.show_src = TRUE,
     teal.snapshot_manager.enable = TRUE,
-    teal.bs_theme = .default_teal_bslib_theming
+    teal.bs_theme = .default_teal_bslib_theming()
   )
 
   op <- options()


### PR DESCRIPTION
# Pull Request

Fixes #1721

Changes `.default_teal_bslib_theming ` to a function. This should make it easier to work and cleans up a bit about the default values if option is missing.