### PR TITLE
Fixes reporter to reset after each session ends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
 * Exported new utility functions to support module decorators: `srv_transform_teal_data()`, `ui_transform_teal_data()` and `check_decorators()` (#1697).
 * Added `teal.snapshot_manager.enable` option (default: `TRUE`) to control whether the Snapshot Manager panel is rendered. Setting it to `FALSE` hides the panel and skips its server logic.
 
+### Bug fixes
+
+* Fixed reporter not resetting after the shiny session ends, which resulted in report cards being persistent across the same application (#XXX).
+
 ### Miscellaneous
 
 * Update maintainer.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 
 ### Bug fixes
 
-* Fixed reporter not resetting after the shiny session ends, which resulted in report cards being persistent across the same application (#XXX).
+* Fixed reporter not resetting after the shiny session ends, which resulted in report cards being persistent across the same application (#1723).
 
 ### Miscellaneous
 

--- a/R/module_teal.R
+++ b/R/module_teal.R
@@ -126,6 +126,12 @@ srv_teal <- function(id, data, modules, filter = teal_slices(), reporter = teal.
   moduleServer(id, function(input, output, session) {
     logger::log_debug("srv_teal initializing.")
 
+    onSessionEnded(function() {
+      if (!is.null(reporter)) {
+        shiny::isolate(reporter$reset())
+      }
+    })
+
     if (getOption("teal.show_js_log", default = FALSE)) {
       shinyjs::showLog()
     }


### PR DESCRIPTION
# Pull Request

Fixes #1723 

### Changes description

- Resets reporter after each session ends

### How to test

- Run a teal app with a module that supports reporter
- Add reporter
- Refresh browser window and look at the existing reports (should be `0`)